### PR TITLE
refactor(field): use UTC for timestamp fields

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         pip install -r requirements-dev.txt
         pip install codecov build
 
-        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev3
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev4
 
     - name: Run tests with coverage
       run: |
@@ -82,7 +82,7 @@ jobs:
           pip install -r requirements-dev.txt
         fi
 
-        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev3
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev4
 
     - name: Run tests
       run: |
@@ -115,7 +115,7 @@ jobs:
           pip install -r requirements-dev.txt
         fi
 
-        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev3
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev4
 
     - name: Run tests
       run: |

--- a/changelog.d/25.changed.md
+++ b/changelog.d/25.changed.md
@@ -1,0 +1,1 @@
+Timestamp fields in `TimestampMixin` now use UTC instead of local time to ensure timezone consistency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,21 +65,6 @@ dependencies = [
     # Provides additional typing features for older Python versions
     "typing-extensions>=4.12.0",
 
-    # World timezone definitions for Python
-    # Required for timezone-aware datetime handling in database operations
-    # Version 2025.2+ includes the latest timezone data
-    "pytz>=2025.2",
-
-    # Extensions to the standard datetime module
-    # Used for robust datetime parsing and manipulation
-    # Version 2.9.0+ provides stable datetime utilities
-    "python-dateutil>=2.9.0",
-
-    # System timezone detection
-    # Automatically detects local timezone for timestamp fields
-    # Version 5.2+ supports modern timezone detection
-    "tzlocal>=5.2",
-
     # Timezone info backport for Python 3.8
     # Python 3.8 lacks native zoneinfo support, this provides compatibility
     # Only required for Python 3.8 as later versions have native zoneinfo

--- a/requirements-3.8.txt
+++ b/requirements-3.8.txt
@@ -9,21 +9,6 @@ pydantic~=2.10.6
 # Version ~=2.27.2 matches pydantic 2.10.6 requirements
 pydantic-core~=2.27.2
 
-# World timezone definitions for Python
-# Required for timezone-aware datetime handling in database operations
-# Version ~=2025.2 includes the latest timezone data
-pytz~=2025.2
-
-# Extensions to the standard datetime module
-# Used for robust datetime parsing and manipulation
-# Version ~=2.9.0.post0 provides stable datetime utilities
-python-dateutil~=2.9.0.post0
-
-# System timezone detection
-# Automatically detects local timezone for timestamp fields
-# Version ~=5.2 is compatible with Python 3.8
-tzlocal~=5.2
-
 # Testing framework for unit and integration tests
 # Required for running the test suite
 # Version ~=8.3.5 provides stable testing capabilities

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,21 +13,6 @@ pydantic>=2.12.0
 # This includes Python 3.14 and any future Python versions
 pydantic-core>=2.41.0
 
-# World timezone definitions for Python
-# Required for timezone-aware datetime handling in database operations
-# Version ~=2025.2 includes the latest timezone data
-pytz~=2025.2
-
-# Extensions to the standard datetime module
-# Used for robust datetime parsing and manipulation
-# Version ~=2.9.0.post0 provides stable datetime utilities
-python-dateutil~=2.9.0.post0
-
-# System timezone detection
-# Automatically detects local timezone for timestamp fields
-# Version ~=5.3.1 supports modern timezone detection
-tzlocal~=5.3.1
-
 # Python packaging utilities
 # Required for package building and distribution
 # Version ~=80.9.0 provides stable packaging tools

--- a/src/rhosocial/activerecord/field/timestamp.py
+++ b/src/rhosocial/activerecord/field/timestamp.py
@@ -1,7 +1,6 @@
 # src/rhosocial/activerecord/field/timestamp.py
 """Module providing timestamp functionality."""
-from datetime import datetime
-import tzlocal
+from datetime import datetime, timezone
 from pydantic import Field
 
 from ..interface import IActiveRecord, ModelEvent
@@ -13,12 +12,8 @@ class TimestampMixin(IActiveRecord):
     Automatically maintains timestamps on record creation/updates.
     """
 
-    __timezone__ = tzlocal.get_localzone()
-
-    created_at: datetime = Field(default_factory=lambda: datetime.now(
-        tzlocal.get_localzone() if TimestampMixin.__timezone__ is None else TimestampMixin.__timezone__))
-    updated_at: datetime = Field(default_factory=lambda: datetime.now(
-        tzlocal.get_localzone() if TimestampMixin.__timezone__ is None else TimestampMixin.__timezone__))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -30,8 +25,7 @@ class TimestampMixin(IActiveRecord):
         Sets created_at for new records.
         Updates updated_at for all saves.
         """
-        now = datetime.now(
-            tzlocal.get_localzone() if TimestampMixin.__timezone__ is None else TimestampMixin.__timezone__)
+        now = datetime.now(timezone.utc)
         if is_new:
             instance.created_at = now
         instance.updated_at = now


### PR DESCRIPTION
The created_at and updated_at fields in TimestampMixin now use UTC to ensure timezone consistency across different environments, aligning with the behavior of SoftDeleteMixin.