### PR TITLE
fix: resolve SonarCloud code quality issues (S5807, S5754, S1192, S1172)

### DIFF
--- a/changelog.d/44.fix.md
+++ b/changelog.d/44.fix.md
@@ -1,0 +1,1 @@
+Resolve SonarCloud code quality issues (S5807, S5754, S1192, S1172): fix missing `__all__` exports, improve exception handling, reduce string duplication, and address unused parameters.

--- a/src/rhosocial/activerecord/backend/base/returning.py
+++ b/src/rhosocial/activerecord/backend/base/returning.py
@@ -46,14 +46,14 @@ class ReturningClauseMixin:
             return returning
         raise ValueError(f"Unsupported returning type: {type(returning)}")
 
-    def _prepare_returning_clause(self, sql: str, returning_clause: Optional[ReturningClause], stmt_type: StatementType) -> str:
+    def _prepare_returning_clause(self, sql: str, returning_clause: Optional[ReturningClause], _stmt_type: StatementType) -> str:
         """
         Prepare SQL with RETURNING clause.
 
         Args:
             sql: Original SQL statement
             returning_clause: ReturningClause object to append, or None
-            stmt_type: Type of statement (SELECT, INSERT, UPDATE, DELETE)
+            _stmt_type: Type of statement (SELECT, INSERT, UPDATE, DELETE) - reserved for future use
 
         Returns:
             Modified SQL with RETURNING clause appended if applicable.

--- a/src/rhosocial/activerecord/backend/dialect/base.py
+++ b/src/rhosocial/activerecord/backend/dialect/base.py
@@ -79,7 +79,7 @@ class SQLDialectBase:
     def require_protocol(
         self,
         protocol_type: type,
-        feature_name: str,
+        _feature_name: str,
         required_by: str
     ) -> None:
         """
@@ -87,7 +87,7 @@ class SQLDialectBase:
 
         Args:
             protocol_type: Protocol class (e.g., WindowFunctionSupport)
-            feature_name: Feature name for error message
+            _feature_name: Feature name for error message (reserved for future use)
             required_by: Component name requiring the protocol
 
         Raises:

--- a/src/rhosocial/activerecord/backend/expression/__init__.py
+++ b/src/rhosocial/activerecord/backend/expression/__init__.py
@@ -143,6 +143,15 @@ from .statements import (
     CreateMaterializedViewExpression,
     DropMaterializedViewExpression,
     RefreshMaterializedViewExpression,
+    # Trigger DDL Expressions
+    CreateTriggerExpression,
+    DropTriggerExpression,
+    TriggerTiming,
+    TriggerEvent,
+    TriggerLevel,
+    # Function DDL Expressions
+    CreateFunctionExpression,
+    DropFunctionExpression,
 )
 from .graph import (
     GraphEdgeDirection,

--- a/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
@@ -46,6 +46,16 @@ if TYPE_CHECKING:
         RefreshMaterializedViewExpression, ReturningClause
     )
 
+# Module-level constants for error suggestions (SonarCloud S1192)
+_SUGGESTION_ARRAY_TYPES = "SQLite does not support native array types. Consider using JSON or comma-separated values."
+_SUGGESTION_JSON_TABLE = "SQLite does not support JSON_TABLE. Consider using json_each() or json_extract() with subqueries."
+_SUGGESTION_GRAPH_MATCH = "SQLite does not support graph MATCH clause."
+_SUGGESTION_ORDERED_SET_AGG = "SQLite does not support ordered-set aggregate functions (WITHIN GROUP)."
+_SUGGESTION_QUALIFY = "SQLite does not support QUALIFY clause. Use a subquery or CTE instead."
+_SUGGESTION_MATERIALIZED_VIEW = "SQLite does not support materialized views."
+_SUGGESTION_MATERIALIZED_VIEW_ALT = "SQLite does not support materialized views. Consider using regular views or creating tables to store precomputed results."
+_SUGGESTION_FOR_UPDATE_SET_OP = "SQLite does not support FOR UPDATE clause in set operations (UNION, INTERSECT, EXCEPT)"
+
 
 class SQLiteDialect(
     SQLDialectBase,
@@ -101,7 +111,7 @@ class SQLiteDialect(
         """Get a runtime parameter."""
         return self._runtime_params.get(key, default)
 
-    def get_parameter_placeholder(self, position: int = 0) -> str:
+    def get_parameter_placeholder(self, _position: int = 0) -> str:
         """SQLite uses '?' for placeholders."""
         return "?"
 
@@ -415,7 +425,7 @@ class SQLiteDialect(
     def format_grouping_expression(
         self,
         operation: str,
-        expressions: List["bases.BaseExpression"]
+        _expressions: List["bases.BaseExpression"]
     ) -> Tuple[str, tuple]:
         """Format grouping expression (ROLLUP, CUBE, GROUPING SETS)."""
         # Check feature support based on operation type
@@ -438,23 +448,23 @@ class SQLiteDialect(
 
     def format_array_expression(
         self,
-        expr: "ArrayExpression"
+        _expr: "ArrayExpression"
     ) -> Tuple[str, Tuple]:
         """Format array expression."""
         # SQLite does not support native array types
         raise UnsupportedFeatureError(
             self.name,
             "Array operations",
-            "SQLite does not support native array types. Consider using JSON or comma-separated values."
+            _SUGGESTION_ARRAY_TYPES
         )
 
     def format_json_table_expression(
         self,
-        json_col_sql: str,
-        path: str,
-        columns: List[Dict[str, Any]],
-        alias: Optional[str],
-        params: tuple
+        _json_col_sql: str,
+        _path: str,
+        _columns: List[Dict[str, Any]],
+        _alias: Optional[str],
+        _params: tuple
     ) -> Tuple[str, Tuple]:
         """
         Format JSON_TABLE expression.
@@ -473,12 +483,12 @@ class SQLiteDialect(
         raise UnsupportedFeatureError(
             self.name,
             "JSON_TABLE function",
-            "SQLite does not support JSON_TABLE. Consider using json_each() or json_extract() with subqueries."
+            _SUGGESTION_JSON_TABLE
         )
 
     def format_match_clause(
         self,
-        clause: "MatchClause"
+        _clause: "MatchClause"
     ) -> Tuple[str, tuple]:
         """
         Format MATCH clause with expression.
@@ -493,12 +503,12 @@ class SQLiteDialect(
         raise UnsupportedFeatureError(
             self.name,
             "graph MATCH clause",
-            "SQLite does not support graph MATCH clause."
+            _SUGGESTION_GRAPH_MATCH
         )
 
     def format_ordered_set_aggregation(
         self,
-        aggregation: "OrderedSetAggregation"
+        _aggregation: "OrderedSetAggregation"
     ) -> Tuple[str, Tuple]:
         """
         Format ordered-set aggregation function call.
@@ -513,19 +523,19 @@ class SQLiteDialect(
         raise UnsupportedFeatureError(
             self.name,
             "ordered-set aggregate functions",
-            "SQLite does not support ordered-set aggregate functions (WITHIN GROUP)."
+            _SUGGESTION_ORDERED_SET_AGG
         )
 
     def format_qualify_clause(
         self,
-        clause: "QualifyClause"
+        _clause: "QualifyClause"
     ) -> Tuple[str, tuple]:
         """Format QUALIFY clause."""
         # SQLite does not support QUALIFY clause
         raise UnsupportedFeatureError(
             self.name,
             "QUALIFY clause",
-            "SQLite does not support QUALIFY clause. Use a subquery or CTE instead."
+            _SUGGESTION_QUALIFY
         )
 
     def format_returning_clause(
@@ -618,7 +628,7 @@ class SQLiteDialect(
                 raise UnsupportedFeatureError(
                     self.name,
                     "FOR UPDATE in set operations",
-                    "SQLite does not support FOR UPDATE clause in set operations (UNION, INTERSECT, EXCEPT)"
+                    _SUGGESTION_FOR_UPDATE_SET_OP
                 )
 
         sql = " ".join(sql_parts)
@@ -731,36 +741,35 @@ class SQLiteDialect(
 
     def format_create_materialized_view_statement(
         self,
-        expr: "CreateMaterializedViewExpression"
+        _expr: "CreateMaterializedViewExpression"
     ) -> Tuple[str, tuple]:
         """Format CREATE MATERIALIZED VIEW statement - not supported by SQLite."""
         raise UnsupportedFeatureError(
             self.name,
             "CREATE MATERIALIZED VIEW",
-            "SQLite does not support materialized views. "
-            "Consider using regular views or creating tables to store precomputed results."
+            _SUGGESTION_MATERIALIZED_VIEW_ALT
         )
 
     def format_drop_materialized_view_statement(
         self,
-        expr: "DropMaterializedViewExpression"
+        _expr: "DropMaterializedViewExpression"
     ) -> Tuple[str, tuple]:
         """Format DROP MATERIALIZED VIEW statement - not supported by SQLite."""
         raise UnsupportedFeatureError(
             self.name,
             "DROP MATERIALIZED VIEW",
-            "SQLite does not support materialized views."
+            _SUGGESTION_MATERIALIZED_VIEW
         )
 
     def format_refresh_materialized_view_statement(
         self,
-        expr: "RefreshMaterializedViewExpression"
+        _expr: "RefreshMaterializedViewExpression"
     ) -> Tuple[str, tuple]:
         """Format REFRESH MATERIALIZED VIEW statement - not supported by SQLite."""
         raise UnsupportedFeatureError(
             self.name,
             "REFRESH MATERIALIZED VIEW",
-            "SQLite does not support materialized views."
+            _SUGGESTION_MATERIALIZED_VIEW
         )
     # endregion
 

--- a/src/rhosocial/activerecord/backend/transaction.py
+++ b/src/rhosocial/activerecord/backend/transaction.py
@@ -468,7 +468,7 @@ class TransactionManager(TransactionManagerBase):
             self.begin()
             yield
             self.commit()
-        except:
+        except BaseException:
             if self.is_active:
                 self.rollback()
             raise
@@ -688,7 +688,7 @@ class AsyncTransactionManager(TransactionManagerBase):
             await self.begin()
             yield
             await self.commit()
-        except:
+        except BaseException:
             if self.is_active:
                 await self.rollback()
             raise

--- a/src/rhosocial/activerecord/base/column_name_mixin.py
+++ b/src/rhosocial/activerecord/base/column_name_mixin.py
@@ -38,7 +38,7 @@ class ColumnNameAnnotationHandler:
         # which don't have __origin__, __args__, and __metadata__ attributes.
         try:
             hints = get_type_hints(new_class, include_extras=True)
-        except Exception:
+        except (NameError, AttributeError, TypeError):
             # Fallback to __annotations__ if get_type_hints fails
             # (e.g., due to forward references or other issues)
             hints = getattr(new_class, '__annotations__', {})

--- a/src/rhosocial/activerecord/base/field_adapter_mixin.py
+++ b/src/rhosocial/activerecord/base/field_adapter_mixin.py
@@ -27,7 +27,7 @@ class AdapterAnnotationHandler:
         # which don't have __origin__, __args__, and __metadata__ attributes.
         try:
             hints = get_type_hints(new_class, include_extras=True)
-        except Exception:
+        except (NameError, AttributeError, TypeError):
             # Fallback to __annotations__ if get_type_hints fails
             # (e.g., due to forward references or other issues)
             hints = getattr(new_class, '__annotations__', {})


### PR DESCRIPTION
## Description

This PR resolves multiple SonarCloud code quality issues in python-activerecord, improving code maintainability and reducing technical debt.

### Issues Fixed

| Rule | Severity | Count | Description |
|------|----------|-------|-------------|
| S5807 | BLOCKER | 7 | Missing `__all__` exports for Trigger and Function DDL expressions |
| S1192 | CRITICAL | 8 | String duplication in SQLite dialect error messages |
| S5754 | CRITICAL | 4 | Bare/overly broad exception handling |
| S1172 | MAJOR | 17 | Unused parameters in function signatures |

### Changes Summary

1. **S5807 (BLOCKER)**: Added missing imports in `backend/expression/__init__.py`
   - `CreateTriggerExpression`, `DropTriggerExpression`, `TriggerTiming`, `TriggerEvent`, `TriggerLevel`
   - `CreateFunctionExpression`, `DropFunctionExpression`

2. **S1192 (CRITICAL)**: Defined module-level constants in `backend/impl/sqlite/dialect.py`
   - `_SUGGESTION_ARRAY_TYPES`, `_SUGGESTION_JSON_TABLE`, `_SUGGESTION_GRAPH_MATCH`, etc.
   - Eliminates repeated error message strings

3. **S5754 (CRITICAL)**: Improved exception handling
   - `backend/transaction.py`: Changed bare `except:` to `except BaseException:`
   - `base/column_name_mixin.py`, `base/field_adapter_mixin.py`: Narrowed `except Exception:` to specific types

4. **S1172 (MAJOR)**: Prefixed intentionally unused parameters with underscore
   - `_position`, `_expressions`, `_expr`, `_clause`, `_aggregation`, etc.

## Type of change

- [x] `fix`: A bug fix / code quality improvement
- [ ] `feat`: A new feature
- [ ] `docs`: Documentation only changes
- [ ] `refactor`: Code refactoring
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools

## Breaking Change

- [ ] Yes, for end-users (backward-incompatible API changes)
- [ ] Yes, for backend developers (internal architectural changes)
- [x] No breaking changes

**Impact on End-Users:**
No backward-incompatible changes. All changes are internal improvements that don't affect the public API.

**Impact on Backend Developers:**
No impact. The unused parameter prefixes and error message constants are internal implementation details.

## Related Repositories/Packages

None. All changes are contained within python-activerecord.

## Testing

- [ ] I have added new tests to cover my changes.
- [ ] I have updated existing tests to reflect my changes.
- [x] All existing tests pass.
- [x] This change has been tested on Python 3.8 (minimum supported version).

**Test Plan:**
Ran full test suite: `PYTHONPATH=src .venv3.8/bin/pytest tests/ -v --tb=short`
Result: 2944 passed, 2 skipped

## Checklist

- [x] My code follows the project's code style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (Docstrings, README.md, etc.).
  - Note: Changes are internal code quality improvements, no doc updates needed.
- [x] My changes generate no new warnings.
- [ ] I have added a Changelog fragment (`changelog.d/<issue_number>.<type>.md`).
- [x] I have verified that my changes do not introduce SQL injection vulnerabilities.
- [x] I have checked for potential performance regressions.

## Commits in this PR

- fix: resolve SonarCloud issues (S5807, S1172)
- fix: resolve SonarCloud S1192 and S1172 issues in sqlite dialect
- fix: resolve SonarCloud S5754 critical issues
