### PR TITLE
feat(backend): add boolean predicates, lazy async loading, and update README

### DIFF
--- a/changelog.d/48.added.md
+++ b/changelog.d/48.added.md
@@ -1,0 +1,1 @@
+Added IS TRUE/FALSE boolean predicates to expression system for proper SQL boolean comparisons that handle three-valued logic (TRUE, FALSE, NULL). Added lazy loading for async SQLite components to allow installation without aiosqlite dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Async support for SQLite backend
+# These are required only when using AsyncSQLiteBackend
+async = [
+    "aiosqlite>=0.19.0",
+    "aiofiles>=23.0.0",
+]
+
 # Database backend dependencies (provided by separate packages)
 # These are distributed as independent packages to maintain modularity
 mysql = ["rhosocial-activerecord-mysql>=1.0.0,<2.0.0"]
@@ -100,6 +107,8 @@ all = [
     "rhosocial-activerecord-oracle>=1.0.0,<2.0.0",
     "rhosocial-activerecord-mssql>=1.0.0,<2.0.0",
     "rhosocial-activerecord-migration>=1.0.0,<2.0.0",
+    "aiosqlite>=0.19.0",
+    "aiofiles>=23.0.0",
 ]
 
 # Development dependencies - These will be installed automatically during pip install -e .

--- a/src/rhosocial/activerecord/backend/README.md
+++ b/src/rhosocial/activerecord/backend/README.md
@@ -1,166 +1,416 @@
-<!-- src/rhosocial/activerecord/backend/README.md -->
-# Design Principles
+# Backend Module Design Documentation
 
-To maintain the Open-Closed Principle and decouple the backend module from specific storage backend implementations, the following adjustments are needed:
+## Overview
 
-1. Module Structure:
-```
+The Backend module is the database abstraction layer for rhosocial-activerecord, responsible for providing a unified database access interface while supporting multiple database backends. This module follows the Open-Closed Principle (OCP), with core interfaces decoupled from concrete implementations, allowing new database support to be added via plugins.
+
+## Architecture Principles
+
+1. **Separation of Abstraction and Implementation**: The core package only defines interfaces and base classes, without any concrete database dependencies
+2. **Protocol-Driven Design**: Uses Protocol and ABC to define feature contracts, supporting fine-grained capability detection
+3. **Sync/Async Symmetry**: Synchronous and asynchronous APIs share core logic, differing only in the I/O layer
+4. **Mixin Composition Pattern**: Backend functionality is composed through multiple Mixin classes, improving code reuse
+
+## Directory Structure
+
+```text
 backend/
-    __init__.py                  # Only exports interfaces and base classes
-    base.py                      # Core interfaces and class definitions
-    config.py                    # Configuration-related classes
-    result.py                    # Query result types
-    schema.py                    # Database schema and type definitions
-    dialect.py                   # Dialect-related abstract definitions
-    errors.py                    # Error definitions
-    helpers.py                   # Helper utilities
-
-impl/                            # Concrete implementations package
-    __init__.py 
-    sqlite/                      # SQLite implementation
-        __init__.py
-        backend.py               # SQLite backend
-        dialect.py               # SQLite dialect
-        types.py                 # SQLite type mapping
-    mysql/                       # MySQL implementation (distributed separately)
-        __init__.py
-        backend.py
-        dialect.py  
-        types.py
-    postgresql/                  # PostgreSQL implementation (distributed separately)
-        __init__.py
-        backend.py
-        dialect.py
-        types.py
+├── __init__.py                  # Public interface exports
+├── config.py                    # Connection configuration base class
+├── errors.py                    # Exception definitions
+├── result.py                    # Query result types
+├── schema.py                    # Database schema and type definitions
+├── helpers.py                   # Common helper functions
+├── options.py                   # Backend options configuration
+├── output.py                    # Output module
+├── output_abc.py                # Output abstract base class
+├── output_rich.py               # Rich library output implementation
+├── type_adapter.py              # Type adapter protocol and presets
+├── type_registry.py             # Type adapter registry
+├── transaction.py               # Transaction management base (sync/async)
+│
+├── base/                        # Backend base classes and Mixins
+│   ├── __init__.py              # StorageBackend and AsyncStorageBackend
+│   ├── base.py                  # Backend base class
+│   ├── connection.py            # Connection management Mixin (sync/async)
+│   ├── execution.py             # Query execution Mixin (sync/async)
+│   ├── hooks.py                 # Execution hooks Mixin (sync/async)
+│   ├── logging.py               # Logging Mixin
+│   ├── operations.py            # SQL operations Mixin (sync/async)
+│   ├── result_processing.py     # Result processing Mixin
+│   ├── returning.py             # RETURNING clause Mixin
+│   ├── sql_building.py          # SQL building Mixin
+│   ├── transaction_management.py # Transaction management Mixin (sync/async)
+│   └── type_adaption.py         # Type adaptation Mixin (sync/async)
+│
+├── dialect/                     # SQL dialect system
+│   ├── __init__.py              # Dialect public interface
+│   ├── base.py                  # SQLDialectBase class
+│   ├── exceptions.py            # Dialect-related exceptions
+│   ├── protocols.py             # Feature protocol definitions
+│   └── mixins.py                # Dialect feature Mixins
+│
+├── expression/                  # SQL expression building blocks
+│   ├── __init__.py              # Expression public interface
+│   ├── bases.py                 # Expression base classes and protocols
+│   ├── literals.py              # Literal expressions
+│   ├── operators.py             # Operator expressions
+│   ├── core.py                  # Core expressions (Column, FunctionCall, etc.)
+│   ├── predicates.py            # Predicate expressions
+│   ├── aggregates.py            # Aggregate functions
+│   ├── advanced_functions.py    # Advanced functions (window, JSON, array, etc.)
+│   ├── functions.py             # Function factories
+│   ├── query_parts.py           # Query components
+│   ├── query_sources.py         # Query sources (CTE, subquery, etc.)
+│   ├── statements.py            # SQL statements (DML/DDL)
+│   ├── mixins.py                # Expression Mixins
+│   └── graph.py                 # Graph query expressions
+│
+└── impl/                        # Concrete backend implementations
+    ├── dummy/                   # Dummy backend (SQL generation only)
+    │   ├── __init__.py
+    │   ├── backend.py           # DummyBackend / AsyncDummyBackend
+    │   └── dialect.py           # DummyDialect
+    │
+    └── sqlite/                  # SQLite implementation (built into core)
+        ├── __init__.py
+        ├── __main__.py          # CLI entry point
+        ├── adapters.py          # SQLite type adapters
+        ├── config.py            # SQLite connection configuration
+        ├── dialect.py           # SQLite dialect
+        ├── functions.py         # SQLite-specific function factories
+        ├── mixins.py            # SQLite-specific Mixins
+        ├── protocols.py         # SQLite-specific protocols
+        ├── transaction.py       # Sync transaction management
+        ├── async_transaction.py # Async transaction management
+        │
+        ├── backend/             # Backend implementation
+        │   ├── __init__.py
+        │   ├── common.py        # Shared logic
+        │   ├── sync.py          # SQLiteBackend (sync)
+        │   └── async_backend.py # AsyncSQLiteBackend (async)
+        │
+        ├── extension/           # Extension framework
+        │   ├── __init__.py
+        │   ├── base.py          # Extension base class
+        │   ├── registry.py      # Extension registry
+        │   └── extensions/      # Built-in extensions
+        │       ├── json1.py     # JSON1 extension
+        │       ├── fts3_4.py    # FTS3/FTS4 full-text search
+        │       ├── fts5.py      # FTS5 full-text search
+        │       ├── rtree.py     # R-Tree spatial index
+        │       └── geopoly.py   # Geopoly polygon
+        │
+        └── pragma/              # PRAGMA management
+            ├── __init__.py
+            ├── base.py          # PRAGMA base class
+            ├── compile_time.py  # Compile-time PRAGMAs
+            ├── config.py        # Configuration PRAGMAs
+            ├── debug.py         # Debug PRAGMAs
+            ├── info.py          # Information PRAGMAs
+            ├── performance.py   # Performance PRAGMAs
+            └── wal.py           # WAL-related PRAGMAs
 ```
 
-2. The backend package only defines interfaces and base classes, without any concrete implementation code or specific database dependencies.
+## Independent Backend Packages
 
-3. Load concrete implementations at runtime through configuration and dynamic importing:
+The following backends are distributed as independent packages, following the naming convention `rhosocial-activerecord-{backend}`:
+
+### MySQL (`python-activerecord-mysql`)
+
+```text
+impl/mysql/
+├── __init__.py
+├── __main__.py              # CLI entry point
+├── backend.py               # MySQLBackend (sync)
+├── async_backend.py         # AsyncMySQLBackend (async)
+├── config.py                # MySQL connection configuration
+├── dialect.py               # MySQL dialect
+├── transaction.py           # Sync transaction management
+├── async_transaction.py     # Async transaction management
+├── types.py                 # MySQL-specific types (ENUM, SET)
+├── adapters.py              # Type adapters
+├── functions.py             # MySQL-specific functions (JSON, spatial, full-text)
+├── mixins.py                # MySQL-specific Mixins
+└── protocols.py             # MySQL-specific protocols
+```
+
+**Driver Dependencies**:
+
+- Sync: `mysql-connector-python`
+- Async: `aiomysql` (optional, via lazy loading)
+
+### PostgreSQL (`python-activerecord-postgres`)
+
+```text
+impl/postgres/
+├── __init__.py
+├── __main__.py              # CLI entry point
+├── config.py                # PostgreSQL connection configuration
+├── dialect.py               # PostgreSQL dialect
+├── transaction.py           # Transaction management
+├── statements.py            # PostgreSQL-specific statements
+├── type_compatibility.py    # Type compatibility mapping
+├── mixins.py                # PostgreSQL-specific Mixins
+├── protocols.py             # PostgreSQL-specific protocols
+│
+├── backend/                 # Backend implementation
+│   ├── __init__.py
+│   ├── base.py              # Shared base class
+│   ├── sync.py              # PostgreSQLBackend (sync)
+│   └── async_backend.py     # AsyncPostgreSQLBackend (async)
+│
+├── types/                   # PostgreSQL-specific types
+│   ├── json.py              # JSON/JSONB
+│   ├── array.py             # Array types
+│   ├── range.py             # Range types
+│   ├── geometric.py         # Geometric types
+│   ├── network_address.py   # Network address types
+│   └── ...                  # Other types
+│
+├── adapters/                # Type adapters
+│   ├── json.py
+│   ├── geometric.py
+│   ├── range.py
+│   └── ...
+│
+└── functions/               # PostgreSQL-specific functions
+    ├── json.py              # JSON functions
+    ├── geometric.py         # Geometric functions
+    ├── range.py             # Range functions
+    └── ...
+```
+
+**Driver Dependencies**:
+
+- `psycopg` (version 3.x) - Supports both sync and async
+
+## Core Components
+
+### StorageBackend / AsyncStorageBackend
+
+Abstract base classes for backends, implementing full functionality through Mixin composition:
+
 ```python
-from rhosocial.activerecord.backend.impl.sqlite import SQLiteBackend
-from rhosocial.activerecord.backend.impl.mysql import MySQLBackend  # If mysql package is installed
+class StorageBackend(
+    StorageBackendBase,
+    LoggingMixin,
+    TypeAdaptionMixin,
+    SQLBuildingMixin,
+    ReturningClauseMixin,
+    ResultProcessingMixin,
+    SQLOperationsMixin,
+    ExecutionMixin,
+    ExecutionHooksMixin,
+    ConnectionMixin,
+    TransactionManagementMixin,
+    ABC,
+):
+    """Synchronous storage backend abstract base class."""
 
-def create_backend(backend_type: str, **config) -> StorageBackend:
-    """Factory function to create concrete backend instances"""
+    @abstractmethod
+    def connect(self) -> None: ...
+
+    @abstractmethod
+    def disconnect(self) -> None: ...
+
+    @abstractmethod
+    def ping(self, reconnect: bool = True) -> bool: ...
+
+    @abstractmethod
+    def get_server_version(self) -> tuple: ...
+```
+
+### Dialect Protocol System
+
+Defines optional advanced features through Protocols, supporting fine-grained capability detection:
+
+```python
+from rhosocial.activerecord.backend.dialect import (
+    SQLDialectBase,
+    WindowFunctionSupport,
+    CTESupport,
+    ReturningSupport,
+    UpsertSupport,
+    JSONSupport,
+    ArraySupport,
+    # ... more protocols
+)
+
+# Check feature support
+dialect = SQLiteDialect()
+if isinstance(dialect, WindowFunctionSupport):
+    if dialect.supports_window_functions():
+        # Use window functions
+        pass
+```
+
+**Available Protocols**:
+
+- **Query Features**: `WindowFunctionSupport`, `CTESupport`, `AdvancedGroupingSupport`, `SetOperationSupport`, `JoinSupport`
+- **Data Operations**: `ReturningSupport`, `UpsertSupport`, `MergeSupport`
+- **Data Types**: `JSONSupport`, `ArraySupport`, `GeneratedColumnSupport`
+- **Query Optimization**: `ExplainSupport`, `FilterClauseSupport`, `OrderedSetAggregationSupport`
+- **Concurrency Control**: `LockingSupport`, `QualifyClauseSupport`
+- **DDL Operations**: `TableSupport`, `ViewSupport`, `IndexSupport`, `SequenceSupport`, `TriggerSupport`, `FunctionSupport`, `SchemaSupport`
+- **Advanced Features**: `LateralJoinSupport`, `TemporalTableSupport`, `GraphSupport`, `ILIKESupport`
+
+### Expression System
+
+SQL expression building blocks, following the Expression-Dialect separation pattern:
+
+```python
+from rhosocial.activerecord.backend.expression import (
+    Column, Literal, FunctionCall,
+    QueryExpression, InsertExpression, UpdateExpression,
+    WindowFunctionCall, CTEExpression,
+    # Function factories
+    count, sum_, avg, row_number, rank,
+    json_extract, array_agg,
+)
+
+# Expressions delegate to dialect for formatting
+# Expression.to_sql() -> Dialect.format_*() -> SQL string and parameters
+```
+
+### Type Adapters
+
+Convert between Python types and database types:
+
+```python
+from rhosocial.activerecord.backend.type_adapter import (
+    SQLTypeAdapter,
+    DateTimeAdapter,
+    JSONAdapter,
+    UUIDAdapter,
+    EnumAdapter,
+    BooleanAdapter,
+    DecimalAdapter,
+    ArrayAdapter,
+)
+
+# Adapters are stateless and thread-safe
+adapter = DateTimeAdapter()
+db_value = adapter.to_database(datetime.now(), str)  # ISO format string
+py_value = adapter.from_database("2024-01-01T00:00:00", datetime)
+```
+
+### Transaction Management
+
+Supports nested transactions (via savepoint) and isolation level control:
+
+```python
+from rhosocial.activerecord.backend.transaction import (
+    TransactionManager,
+    AsyncTransactionManager,
+    IsolationLevel,
+    TransactionState,
+)
+
+# Sync transaction
+with backend.transaction_manager.transaction():
+    # Nested transactions automatically use savepoints
+    with backend.transaction_manager.transaction():
+        # ...
+        pass
+
+# Async transaction
+async with backend.transaction_manager.transaction():
+    # ...
+    pass
+```
+
+### Dummy Backend
+
+For generating SQL without an actual database connection:
+
+```python
+from rhosocial.activerecord.backend.impl.dummy import DummyBackend
+
+backend = DummyBackend()
+# All operations requiring a real connection will raise NotImplementedError
+# But SQL generation works correctly
+```
+
+## Database Feature Comparison
+
+| Feature | SQLite | MySQL | PostgreSQL |
+|---------|--------|-------|------------|
+| **RETURNING Support** | ✅ v3.35.0+ | ❌ | ✅ All versions |
+| **CTE** | ✅ v3.8.3+ | ✅ v8.0+ | ✅ All versions |
+| **Recursive CTE** | ✅ | ✅ v8.0+ | ✅ |
+| **Window Functions** | ✅ v3.25.0+ | ✅ v8.0+ | ✅ |
+| **JSON Operations** | ✅ v3.38.0+ | ✅ | ✅ (JSONB) |
+| **Array Types** | ❌ | ❌ | ✅ |
+| **Upsert** | ✅ ON CONFLICT | ✅ ON DUPLICATE KEY | ✅ ON CONFLICT |
+| **MERGE** | ❌ | ✅ | ✅ |
+| **LATERAL JOIN** | ❌ | ✅ v8.0.14+ | ✅ |
+| **Graph Queries** | ❌ | ❌ | ❌ (planned) |
+| **Async Support** | ✅ (aiosqlite) | ✅ (aiomysql) | ✅ (psycopg async) |
+
+## Usage Examples
+
+### Basic Configuration
+
+```python
+from rhosocial.activerecord import ActiveRecord
+from rhosocial.activerecord.backend.impl.sqlite import SQLiteBackend
+
+class User(ActiveRecord):
+    id: int
+    name: str
+    email: str
+
+    class Meta:
+        table_name = "users"
+
+# Configure backend
+User.configure(
+    connection_config={"database": "app.db"},
+    backend_class=SQLiteBackend
+)
+```
+
+### Dynamic Backend Loading
+
+```python
+def create_backend(backend_type: str, **config):
+    """Factory function to create backend instances."""
     if backend_type == 'sqlite':
+        from rhosocial.activerecord.backend.impl.sqlite import SQLiteBackend
         return SQLiteBackend(**config)
     elif backend_type == 'mysql':
+        from rhosocial.activerecord.backend.impl.mysql import MySQLBackend
         return MySQLBackend(**config)
+    elif backend_type == 'postgres':
+        from rhosocial.activerecord.backend.impl.postgres import PostgreSQLBackend
+        return PostgreSQLBackend(**config)
     else:
         raise ValueError(f"Unsupported backend type: {backend_type}")
 ```
 
-4. For testing, use a separate test_implementations package for different backend test code.
-
-Benefits of this design:
-
-1. The backend module only depends on abstract interfaces
-2. Adding database support doesn't require modifying existing code
-3. Users can import database implementations as needed
-4. Test code is better organized
-
-## Details of Each Module
+### Async Backend Usage
 
 ```python
-# backend/
-    # __init__.py
-    """Exports public interfaces only
-    from .base import StorageBackend
-    from .config import ConnectionConfig
-    from .schema import DatabaseType
-    from .result import QueryResult
-    from .errors import DatabaseError, ConnectionError
-    """
+from rhosocial.activerecord.backend.impl.sqlite import AsyncSQLiteBackend
 
-    # base.py  
-    """Core abstract base class for storage backends
-    - StorageBackend ABC
-    - Basic CRUD interface definitions 
-    - Connection management interface
-    - Transaction management interface
-    Without any concrete implementation or database-specific code
-    """
+async def main():
+    backend = AsyncSQLiteBackend(database=":memory:")
+    await backend.connect()
 
-    # config.py
-    """Configuration-related data classes
-    - ConnectionConfig
-    - and other configuration-related classes
-    """
+    async with backend.transaction_manager.transaction():
+        # Execute query
+        result = await backend.execute("SELECT * FROM users")
+        print(result.rows)
 
-    # result.py
-    """Query result types
-    - QueryResult
-    - and other result-related types
-    """
-
-    # schema.py
-    """Database schema and type definitions
-    - DatabaseType enum (unified type system)
-    - and other schema-related types
-    """
-
-    # dialect.py
-    """SQL dialect-related abstract definitions
-    - TypeMapping interface (type mapping rules)
-    - ValueMapper interface (value conversion rules) 
-    Without specific database mapping implementations
-    """
-
-    # errors.py
-    """Error class definitions
-    - DatabaseError base class
-    - ConnectionError
-    - TransactionError
-    - ValidationError
-    And other core exception class definitions
-    """
-
-    # helpers.py
-    """Common helper utilities
-    - Type conversion utility functions
-    - SQL building helper functions
-    - Connection utility functions
-    And other database-agnostic utility functions
-    """
+    await backend.disconnect()
 ```
 
-# Database Backend Implementation Comparison
+## Design Benefits
 
-| Feature | SQLite | MySQL | MariaDB | PostgreSQL |
-|---------|--------|-------|---------|------------|
-| **RETURNING Support** | ✅ Since v3.35.0 | ❌ Not supported | ✅ Since v10.5.0 | ✅ All versions |
-| **Python Version Compatibility** | ⚠️ Issues with 3.9 and below | N/A | ✅ All versions | ✅ All versions |
-| **Expression Support** | ✅ Basic expressions | N/A | ✅ Basic expressions | ✅ Complex expressions |
-| **RETURNING Emulation** | N/A | ⚠️ Limited fallback | N/A | N/A |
-
-## Hook Method Implementation Status
-
-| Hook Method | SQLite | MySQL | MariaDB |
-|-------------|--------|-------|---------|
-| `_get_statement_type` | ✅ Custom | ❌ Base | ❌ Base |
-| `_is_select_statement` | ✅ Custom | ✅ Custom | ✅ Custom |
-| `_is_dml_statement` | ❌ Base | ❌ Base | ❌ Base |
-| `_prepare_returning_clause` | ❌ Base | ✅ Custom | ✅ Custom |
-| `_get_cursor` | ✅ Custom | ✅ Custom | ✅ Custom |
-| `_execute_query` | ✅ Custom | ❌ Base | ✅ Custom |
-| `_process_result_set` | ✅ Custom | ✅ Custom | ✅ Custom |
-| `_build_query_result` | ❌ Base | ✅ Custom | ✅ Custom |
-| `_handle_auto_commit_if_needed` | ✅ Custom | ✅ Custom | ✅ Custom |
-| `_handle_execution_error` | ✅ Custom | ✅ Custom | ✅ Custom |
-
-## Database-Specific Features
-
-### SQLite
-- PRAGMA statements handled as special case
-- Python version compatibility checks
-- SQLite version compatibility checks
-
-### MySQL
-- RETURNING clause emulation for INSERT with LAST_INSERT_ID()
-- Separate query for fetching after INSERT
-- Limited UPDATE/DELETE tracking
-
-### MariaDB
-- Version compatibility checks for RETURNING
-- Custom error handling for specific MariaDB error codes
+1. **Extensibility**: Adding new database support requires no changes to core code
+2. **Testability**: DummyBackend supports database-free testing
+3. **Flexibility**: Protocol system supports runtime feature detection
+4. **Code Reuse**: Mixin composition avoids duplication, sync/async share logic
+5. **Type Safety**: Complete type hints, supporting IDE auto-completion
+6. **Decoupling**: Core package has no concrete database driver dependencies

--- a/src/rhosocial/activerecord/backend/dialect/base.py
+++ b/src/rhosocial/activerecord/backend/dialect/base.py
@@ -379,6 +379,39 @@ class SQLDialectBase:
         sql = f"{expr_sql} IS{not_str} NULL"
         return sql, expr_params
 
+    def format_is_boolean_predicate(
+        self,
+        expr: "bases.BaseExpression",
+        value: bool,
+        is_not: bool
+    ) -> Tuple[str, Tuple]:
+        """Format IS TRUE/FALSE predicate.
+
+        Generates SQL for IS TRUE, IS NOT TRUE, IS FALSE, or IS NOT FALSE predicates.
+        These predicates properly handle three-valued logic (TRUE, FALSE, NULL).
+
+        Args:
+            expr: The expression to test
+            value: True for IS TRUE/FALSE, False for IS FALSE/TRUE
+            is_not: True for IS NOT TRUE/FALSE, False for IS TRUE/FALSE
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+
+        Example:
+            >>> # IS TRUE
+            >>> dialect.format_is_boolean_predicate(col, True, False)
+            ('"is_active" IS TRUE', ())
+            >>> # IS NOT TRUE
+            >>> dialect.format_is_boolean_predicate(col, True, True)
+            ('"is_active" IS NOT TRUE', ())
+        """
+        expr_sql, expr_params = expr.to_sql()
+        not_str = " NOT" if is_not else ""
+        bool_str = "TRUE" if value else "FALSE"
+        sql = f"{expr_sql} IS{not_str} {bool_str}"
+        return sql, expr_params
+
     def format_exists_expression(
         self,
         subquery: "bases.BaseExpression",

--- a/src/rhosocial/activerecord/backend/expression/__init__.py
+++ b/src/rhosocial/activerecord/backend/expression/__init__.py
@@ -46,6 +46,7 @@ from .predicates import (
     InPredicate,
     BetweenPredicate,
     IsNullPredicate,
+    IsBooleanPredicate,
 )
 from .aggregates import (
     AggregateFunctionCall,
@@ -213,7 +214,7 @@ __all__ = [
 
     # Predicates
     "ComparisonPredicate", "LogicalPredicate", "LikePredicate", "InPredicate",
-    "BetweenPredicate", "IsNullPredicate",
+    "BetweenPredicate", "IsNullPredicate", "IsBooleanPredicate",
 
     # Aggregates
     "AggregateFunctionCall",

--- a/src/rhosocial/activerecord/backend/expression/mixins.py
+++ b/src/rhosocial/activerecord/backend/expression/mixins.py
@@ -30,7 +30,7 @@ from typing import Any, Union, List, TYPE_CHECKING, TypeVar
 if TYPE_CHECKING:  # pragma: no cover
     from .bases import SQLValueExpression, SQLPredicate
     from .core import Literal
-    from .predicates import ComparisonPredicate, InPredicate, IsNullPredicate, LogicalPredicate, BetweenPredicate
+    from .predicates import ComparisonPredicate, InPredicate, IsNullPredicate, IsBooleanPredicate, LogicalPredicate, BetweenPredicate
 
 T = TypeVar('T')
 
@@ -222,6 +222,78 @@ class ComparisonMixin:
         """
         from .predicates import IsNullPredicate
         return IsNullPredicate(self.dialect, self, is_not=True)
+
+    def is_true(self: "SQLValueExpression") -> "SQLPredicate":
+        """
+        Generate an IS TRUE predicate for this expression.
+
+        IS TRUE matches only TRUE values, not FALSE or NULL.
+        This is different from = TRUE which would not match NULL values
+        but also wouldn't correctly handle three-valued logic.
+
+        Returns:
+            SQLPredicate representing the IS TRUE check
+
+        Example:
+            >>> col = Column(dialect, "is_active")
+            >>> predicate = col.is_true()  # Generates: "is_active IS TRUE"
+        """
+        from .predicates import IsBooleanPredicate
+        return IsBooleanPredicate(self.dialect, self, value=True, is_not=False)
+
+    def is_not_true(self: "SQLValueExpression") -> "SQLPredicate":
+        """
+        Generate an IS NOT TRUE predicate for this expression.
+
+        IS NOT TRUE matches FALSE values and NULL values.
+        This is useful for finding records where a boolean field is
+        either explicitly false or unset (NULL).
+
+        Returns:
+            SQLPredicate representing the IS NOT TRUE check
+
+        Example:
+            >>> col = Column(dialect, "is_active")
+            >>> predicate = col.is_not_true()  # Generates: "is_active IS NOT TRUE"
+        """
+        from .predicates import IsBooleanPredicate
+        return IsBooleanPredicate(self.dialect, self, value=True, is_not=True)
+
+    def is_false(self: "SQLValueExpression") -> "SQLPredicate":
+        """
+        Generate an IS FALSE predicate for this expression.
+
+        IS FALSE matches only FALSE values, not TRUE or NULL.
+        This is different from = FALSE which would not match NULL values
+        but also wouldn't correctly handle three-valued logic.
+
+        Returns:
+            SQLPredicate representing the IS FALSE check
+
+        Example:
+            >>> col = Column(dialect, "is_deleted")
+            >>> predicate = col.is_false()  # Generates: "is_deleted IS FALSE"
+        """
+        from .predicates import IsBooleanPredicate
+        return IsBooleanPredicate(self.dialect, self, value=False, is_not=False)
+
+    def is_not_false(self: "SQLValueExpression") -> "SQLPredicate":
+        """
+        Generate an IS NOT FALSE predicate for this expression.
+
+        IS NOT FALSE matches TRUE values and NULL values.
+        This is useful for finding records where a boolean field is
+        either explicitly true or unset (NULL).
+
+        Returns:
+            SQLPredicate representing the IS NOT FALSE check
+
+        Example:
+            >>> col = Column(dialect, "is_deleted")
+            >>> predicate = col.is_not_false()  # Generates: "is_deleted IS NOT FALSE"
+        """
+        from .predicates import IsBooleanPredicate
+        return IsBooleanPredicate(self.dialect, self, value=False, is_not=True)
 
     def in_(self: "SQLValueExpression", values: List[Any]) -> "SQLPredicate":
         """

--- a/src/rhosocial/activerecord/backend/expression/predicates.py
+++ b/src/rhosocial/activerecord/backend/expression/predicates.py
@@ -81,7 +81,29 @@ class BetweenPredicate(bases.SQLPredicate):
 
 
 class IsNullPredicate(bases.SQLPredicate):
-    """Represents an IS NULL or IS NOT NULL predicate."""
+    """Represents an IS NULL or IS NOT NULL predicate.
+
+    This predicate is implemented as a separate method (is_null()/is_not_null())
+    rather than using Python's ``is`` operator because:
+
+    1. Python's ``is`` operator cannot be overloaded - it always performs
+       identity comparison (checking if two variables reference the same object).
+    2. ``is`` is a keyword in Python, not a method name, so it cannot be
+       used as a method name on expression objects.
+    3. SQL's ``IS NULL`` has different semantics from Python's ``is None`` -
+       SQL uses three-valued logic (TRUE, FALSE, NULL), while Python's ``is``
+       checks object identity.
+
+    Therefore, we provide ``is_null()`` and ``is_not_null()`` methods in
+    ComparisonMixin to enable intuitive SQL IS NULL predicate generation.
+
+    Example:
+        >>> col = Column(dialect, "email")
+        >>> col.is_null().to_sql()
+        ('"email" IS NULL', ())
+        >>> col.is_not_null().to_sql()
+        ('"email" IS NOT NULL', ())
+    """
     def __init__(self, dialect: "SQLDialectBase", expr: "bases.BaseExpression", is_not: bool = False):
         super().__init__(dialect)
         self.expr = expr
@@ -90,3 +112,59 @@ class IsNullPredicate(bases.SQLPredicate):
     def to_sql(self) -> 'bases.SQLQueryAndParams':
         # Delegate to the dialect's format_is_null_predicate method with the whole expression
         return self.dialect.format_is_null_predicate(self.expr, self.is_not)
+
+
+class IsBooleanPredicate(bases.SQLPredicate):
+    """Represents an IS TRUE, IS NOT TRUE, IS FALSE, or IS NOT FALSE predicate.
+
+    This predicate is used for proper boolean comparisons in SQL, handling
+    NULL values correctly. Unlike direct equality comparisons (= TRUE or = FALSE),
+    IS TRUE/FALSE properly handles NULL values:
+
+    - IS TRUE: matches only TRUE values (not FALSE or NULL)
+    - IS NOT TRUE: matches FALSE and NULL values
+    - IS FALSE: matches only FALSE values (not TRUE or NULL)
+    - IS NOT FALSE: matches TRUE and NULL values
+
+    This predicate is implemented as separate methods (is_true(), is_not_true(),
+    is_false(), is_not_false()) rather than using Python's ``is`` operator because:
+
+    1. Python's ``is`` operator cannot be overloaded - it always performs
+       identity comparison (checking if two variables reference the same object).
+    2. ``is`` is a keyword in Python, not a method name, so it cannot be
+       used as a method name on expression objects.
+    3. SQL's ``IS TRUE/FALSE`` has different semantics from Python's ``is True/False`` -
+       SQL uses three-valued logic (TRUE, FALSE, NULL), while Python's ``is``
+       checks object identity.
+
+    Example:
+        >>> col = Column(dialect, "is_active")
+        >>> col.is_true().to_sql()
+        ('"is_active" IS TRUE', ())
+        >>> col.is_not_true().to_sql()
+        ('"is_active" IS NOT TRUE', ())
+    """
+    def __init__(
+        self,
+        dialect: "SQLDialectBase",
+        expr: "bases.BaseExpression",
+        value: bool,
+        is_not: bool = False
+    ):
+        """
+        Initialize an IS TRUE/FALSE predicate.
+
+        Args:
+            dialect: The SQL dialect to use for formatting
+            expr: The expression to test
+            value: True for IS TRUE/FALSE, False for IS FALSE/TRUE
+            is_not: True for IS NOT TRUE/FALSE, False for IS TRUE/FALSE
+        """
+        super().__init__(dialect)
+        self.expr = expr
+        self.value = value
+        self.is_not = is_not
+
+    def to_sql(self) -> 'bases.SQLQueryAndParams':
+        # Delegate to the dialect's format_is_boolean_predicate method
+        return self.dialect.format_is_boolean_predicate(self.expr, self.value, self.is_not)

--- a/src/rhosocial/activerecord/backend/impl/sqlite/__init__.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/__init__.py
@@ -4,10 +4,14 @@ SQLite backend implementation for ActiveRecord.
 
 This module provides a complete SQLite backend implementation for the ActiveRecord ORM,
 including connection management, dialect support, type adapters, and query execution.
+
+Async components (AsyncSQLiteBackend, AsyncSQLiteTransactionManager) are loaded lazily
+to avoid requiring aiosqlite for users who only need synchronous operations.
+Install the async extra to use:
+    pip install rhosocial-activerecord[async]
 """
 
 from .backend.sync import SQLiteBackend
-from .backend.async_backend import AsyncSQLiteBackend
 from .config import SQLiteConnectionConfig
 from .dialect import SQLiteDialect
 from .adapters import (
@@ -19,7 +23,6 @@ from .transaction import (
     SQLiteTransactionManager,
     SQLiteTransactionMixin
 )
-from .async_transaction import AsyncSQLiteTransactionManager
 from .protocols import SQLiteExtensionSupport, SQLitePragmaSupport
 from .mixins import FTS5Mixin, SQLitePragmaMixin, SQLiteExtensionMixin
 
@@ -173,3 +176,39 @@ __all__ = [
     'rtrim',
     'iif',
 ]
+
+
+def __getattr__(name: str):
+    """Lazily load async components to avoid forcing aiosqlite dependency.
+
+    This allows users to import SQLiteBackend and other sync components without
+    having aiosqlite installed. Only when async components are actually accessed
+    will aiosqlite be required.
+
+    Lazily loaded components:
+    - AsyncSQLiteBackend: Async SQLite backend implementation
+    - AsyncSQLiteTransactionManager: Async transaction manager
+
+    Raises:
+        ImportError: If aiosqlite is not installed when accessing async components.
+        AttributeError: If the requested attribute doesn't exist.
+    """
+    _lazy_imports = {
+        'AsyncSQLiteBackend': ('.backend.async_backend', 'AsyncSQLiteBackend'),
+        'AsyncSQLiteTransactionManager': ('.async_transaction', 'AsyncSQLiteTransactionManager'),
+    }
+
+    if name in _lazy_imports:
+        module_path, class_name = _lazy_imports[name]
+        try:
+            import importlib
+            module = importlib.import_module(module_path, __name__)
+            return getattr(module, class_name)
+        except ImportError as e:
+            raise ImportError(
+                f"{name} requires 'aiosqlite' package. "
+                f"Install it with: pip install rhosocial-activerecord[async] "
+                f"or pip install aiosqlite"
+            ) from e
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/rhosocial/activerecord/backend/impl/sqlite/backend/__init__.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/backend/__init__.py
@@ -3,15 +3,41 @@
 SQLite backend implementations.
 
 This module provides both synchronous and asynchronous SQLite backend implementations.
+
+Async components (AsyncSQLiteBackend) are loaded lazily to avoid requiring aiosqlite
+for users who only need synchronous operations. Install the async extra to use:
+    pip install rhosocial-activerecord[async]
 """
 from .sync import SQLiteBackend
-from .async_backend import AsyncSQLiteBackend
 from .common import SQLiteBackendMixin, DEFAULT_PRAGMAS
 
 __all__ = [
     'SQLiteBackend',
-    'AsyncSQLiteBackend',
+    'AsyncSQLiteBackend',  # Lazily loaded via __getattr__
     'SQLiteBackendMixin',
     'DEFAULT_PRAGMAS',
 ]
+
+
+def __getattr__(name: str):
+    """Lazily load AsyncSQLiteBackend to avoid forcing aiosqlite dependency.
+
+    This allows users to import SQLiteBackend without having aiosqlite installed.
+    Only when AsyncSQLiteBackend is actually accessed will aiosqlite be required.
+
+    Raises:
+        ImportError: If aiosqlite is not installed when accessing AsyncSQLiteBackend.
+        AttributeError: If the requested attribute doesn't exist.
+    """
+    if name == 'AsyncSQLiteBackend':
+        try:
+            from .async_backend import AsyncSQLiteBackend as backend
+            return backend
+        except ImportError as e:
+            raise ImportError(
+                "AsyncSQLiteBackend requires 'aiosqlite' package. "
+                "Install it with: pip install rhosocial-activerecord[async] "
+                "or pip install aiosqlite"
+            ) from e
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/tests/rhosocial/activerecord_test/feature/backend/dummy2/test_expressions_predicates.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/dummy2/test_expressions_predicates.py
@@ -2,7 +2,8 @@
 import pytest
 from rhosocial.activerecord.backend.expression import (
     Column, Literal, RawSQLExpression, Subquery,
-    ComparisonPredicate, LogicalPredicate, InPredicate, BetweenPredicate, IsNullPredicate, LikePredicate
+    ComparisonPredicate, LogicalPredicate, InPredicate, BetweenPredicate, IsNullPredicate, LikePredicate,
+    IsBooleanPredicate
 )
 from rhosocial.activerecord.backend.impl.dummy.dialect import DummyDialect
 
@@ -129,4 +130,50 @@ class TestPredicateExpressions:
         sql, params = composite_pred.to_sql()
         assert sql == '"age" > ? AND "status" = ? OR "name" LIKE ?'
         assert params == (25, "active", "J%")
+
+    @pytest.mark.parametrize("expr_data, value, is_not, expected_sql, expected_params", [
+        ((Column, ("is_active",)), True, False, '"is_active" IS TRUE', ()),
+        ((Column, ("is_active",)), True, True, '"is_active" IS NOT TRUE', ()),
+        ((Column, ("is_deleted",)), False, False, '"is_deleted" IS FALSE', ()),
+        ((Column, ("is_deleted",)), False, True, '"is_deleted" IS NOT FALSE', ()),
+        ((RawSQLExpression, ("verified",)), True, False, 'verified IS TRUE', ()),
+        ((RawSQLExpression, ("verified",)), False, True, 'verified IS NOT FALSE', ()),
+    ])
+    def test_is_boolean_predicate(self, dummy_dialect: DummyDialect, expr_data, value, is_not, expected_sql, expected_params):
+        """Tests IS TRUE/FALSE predicates."""
+        expr = expr_data[0](dummy_dialect, *expr_data[1])
+        pred = IsBooleanPredicate(dummy_dialect, expr, value=value, is_not=is_not)
+        sql, params = pred.to_sql()
+        assert sql == expected_sql
+        assert params == expected_params
+
+    def test_is_boolean_mixin_methods(self, dummy_dialect: DummyDialect):
+        """Tests is_true(), is_not_true(), is_false(), is_not_false() methods."""
+        col = Column(dummy_dialect, "flag")
+
+        sql, params = col.is_true().to_sql()
+        assert sql == '"flag" IS TRUE'
+        assert params == ()
+
+        sql, params = col.is_not_true().to_sql()
+        assert sql == '"flag" IS NOT TRUE'
+        assert params == ()
+
+        sql, params = col.is_false().to_sql()
+        assert sql == '"flag" IS FALSE'
+        assert params == ()
+
+        sql, params = col.is_not_false().to_sql()
+        assert sql == '"flag" IS NOT FALSE'
+        assert params == ()
+
+    def test_is_boolean_with_logical_combination(self, dummy_dialect: DummyDialect):
+        """Tests IS TRUE/FALSE combined with logical predicates."""
+        is_active = Column(dummy_dialect, "is_active").is_true()
+        age_pred = ComparisonPredicate(dummy_dialect, ">", Column(dummy_dialect, "age"), Literal(dummy_dialect, 18))
+
+        combined = LogicalPredicate(dummy_dialect, "AND", is_active, age_pred)
+        sql, params = combined.to_sql()
+        assert sql == '"is_active" IS TRUE AND "age" > ?'
+        assert params == (18,)
 


### PR DESCRIPTION
## Description

This PR introduces three enhancements to the backend module:

### 1. IS TRUE/FALSE Boolean Predicates

Add `IsBooleanPredicate` class and `is_true()`, `is_not_true()`, `is_false()`, `is_not_false()` methods to `ComparisonMixin` for proper SQL boolean comparisons that handle three-valued logic (TRUE, FALSE, NULL).

Unlike direct equality comparisons (`= TRUE/FALSE`), these predicates correctly handle NULL values:
- `IS TRUE`: matches only TRUE values
- `IS NOT TRUE`: matches FALSE and NULL values
- `IS FALSE`: matches only FALSE values
- `IS NOT FALSE`: matches TRUE and NULL values

Note: These are implemented as separate methods because Python's `is` operator cannot be overloaded - it always performs identity comparison.

### 2. Lazy Load Async SQLite Components

Use PEP 562 `__getattr__` for lazy loading of `AsyncSQLiteBackend` and `AsyncSQLiteTransactionManager`. This allows users to import `SQLiteBackend` without having `aiosqlite` installed.

- Add `async` extra in `pyproject.toml` for async dependencies
- Update `all` extra to include `aiosqlite` and `aiofiles`
- Provide clear `ImportError` when async components used without `aiosqlite`

Usage:
- Sync users: `pip install rhosocial-activerecord`
- Async users: `pip install rhosocial-activerecord[async]`

### 3. Backend README Update

The backend module has evolved significantly since the original README was written. This update brings the documentation in line with the actual implementation:

- Add overview and architecture principles (OCP, protocol-driven design)
- Update directory structure (`base/`, `dialect/`, `expression/`, `impl/`)
- Document independent backend packages (MySQL, PostgreSQL)
- Add core component documentation
- Add database feature comparison table
- Add usage examples

## Type of change

- [x] `feat`: A new feature
- [x] `docs`: Documentation only changes (if related to the new feature)
- [ ] `perf`: A code change that improves performance (if part of the feature)
- [ ] `test`: Adding missing tests or correcting existing tests (for the new feature)
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries suchs as documentation generation (if related to the new feature)
- [ ] `ci`: Changes to our CI configuration files and scripts (if related to the new feature)
- [ ] `build`: Changes that affect the build system or external dependencies (if related to the new feature)
- [ ] `revert`: Reverts a previous commit

## Breaking Change

- [ ] Yes, for end-users (backward-incompatible API changes)
- [ ] Yes, for backend developers (internal architectural changes that may affect custom implementations)
- [x] No breaking changes

**Impact on End-Users:**
No backward-incompatible changes are expected for typical end-user applications.

**Impact on Backend Developers (Custom Implementations):**
No backward-incompatible changes are expected for backend developers using custom implementations.

## Related Repositories/Packages

None - this change is self-contained within the core package.

## Testing

- [ ] I have added new tests to cover my changes.
- [ ] I have updated existing tests to reflect my changes.
- [x] All existing tests pass.
- [x] This change has been tested on Python 3.8 (minimum supported version).

**Test Plan:**
```bash
PYTHONPATH=src .venv3.8/bin/pytest tests/ -v --tb=short
# Result: 2993 passed, 2 skipped, 1 deselected, 4 warnings in 14.93s
```

## Checklist

- [x] My code follows the project's code style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (Docstrings, `README.md`, etc.).
- [x] My changes generate no new warnings.
- [ ] I have added a Changelog fragment (`changelog.d/<issue_number>.<type>.md`).
- [x] I have verified that my changes do not introduce SQL injection vulnerabilities.
- [x] I have checked for potential performance regressions.

## Commits in this PR

1. **feat(backend): add IS TRUE/FALSE boolean predicates to expression system** - `cd0eb47`
2. **feat(backend): lazy load async SQLite components to avoid forcing aiosqlite** - `43cbc4e`
3. **docs(backend): update README.md to reflect current module architecture** - `53700da`

## Additional Notes

The lazy loading change allows users who only need synchronous SQLite support to install the core package without the async dependencies (`aiosqlite`, `aiofiles`), reducing the installation footprint for common use cases.
