### PR TITLE
feat(sqlite): add JSON and math function factories

### DIFF
--- a/changelog.d/70.added.md
+++ b/changelog.d/70.added.md
@@ -1,0 +1,1 @@
+Added SQLite JSON function factories and enhanced math function factories.

--- a/src/rhosocial/activerecord/backend/impl/sqlite/__init__.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/__init__.py
@@ -94,7 +94,7 @@ from .functions import (
     sign,
     total,
     # Math enhanced functions
-    round_sql,
+    round_,
     pow,
     power,
     sqrt,
@@ -102,8 +102,8 @@ from .functions import (
     ceil,
     floor,
     trunc,
-    max_sql,
-    min_sql,
+    max_,
+    min_,
     avg,
     # Blob functions
     zeroblob,
@@ -220,7 +220,7 @@ __all__ = [
     "rtrim",
     "iif",
     # Math enhanced functions
-    "round_sql",
+    "round_",
     "pow",
     "power",
     "sqrt",
@@ -228,8 +228,8 @@ __all__ = [
     "ceil",
     "floor",
     "trunc",
-    "max_sql",
-    "min_sql",
+    "max_",
+    "min_",
     "avg",
     # JSON functions
     "json",

--- a/src/rhosocial/activerecord/backend/impl/sqlite/__init__.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/__init__.py
@@ -70,6 +70,7 @@ from .pragma import (
 
 # SQLite-specific function factories
 from .functions import (
+    # String functions
     substr,
     instr,
     printf,
@@ -81,22 +82,60 @@ from .functions import (
     trim_sqlite,
     ltrim,
     rtrim,
+    # Date/Time functions
     date_func,
     time_func,
     datetime_func,
     julianday,
     strftime_func,
+    # Math functions
     random_func,
     abs_sql,
     sign,
     total,
+    # Math enhanced functions
+    round_sql,
+    pow,
+    power,
+    sqrt,
+    mod,
+    ceil,
+    floor,
+    trunc,
+    max_sql,
+    min_sql,
+    avg,
+    # Blob functions
     zeroblob,
     randomblob,
+    # System functions
     typeof,
     quote,
     last_insert_rowid,
     changes,
+    # Conditional functions
     iif,
+    # JSON functions
+    json,
+    json_array,
+    json_object,
+    json_extract,
+    json_type,
+    json_valid,
+    json_quote,
+    json_remove,
+    json_set,
+    json_insert,
+    json_replace,
+    json_patch,
+    json_array_length,
+    json_array_unpack,
+    json_object_pack,
+    json_object_retrieve,
+    json_object_length,
+    json_object_keys,
+    json_tree,
+    json_each,
 )
 
 __all__ = [
@@ -180,6 +219,39 @@ __all__ = [
     "ltrim",
     "rtrim",
     "iif",
+    # Math enhanced functions
+    "round_sql",
+    "pow",
+    "power",
+    "sqrt",
+    "mod",
+    "ceil",
+    "floor",
+    "trunc",
+    "max_sql",
+    "min_sql",
+    "avg",
+    # JSON functions
+    "json",
+    "json_array",
+    "json_object",
+    "json_extract",
+    "json_type",
+    "json_valid",
+    "json_quote",
+    "json_remove",
+    "json_set",
+    "json_insert",
+    "json_replace",
+    "json_patch",
+    "json_array_length",
+    "json_array_unpack",
+    "json_object_pack",
+    "json_object_retrieve",
+    "json_object_length",
+    "json_object_keys",
+    "json_tree",
+    "json_each",
 ]
 
 

--- a/src/rhosocial/activerecord/backend/impl/sqlite/functions/__init__.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/functions/__init__.py
@@ -9,9 +9,11 @@ Submodules:
 - string: String manipulation functions (substr, instr, printf, etc.)
 - datetime: Date and time functions (date, time, datetime, etc.)
 - math: Mathematical functions (random, abs, sign, total)
+- math_enhanced: Enhanced math functions (round, pow, sqrt, mod, etc.)
 - blob: BLOB manipulation functions (zeroblob, randomblob)
 - system: System and type functions (typeof, quote, last_insert_rowid, changes)
 - conditional: Conditional expressions (iif)
+- json: JSON functions (json, json_extract, json_object, etc.)
 """
 
 from .string import (
@@ -59,6 +61,43 @@ from .conditional import (
     iif,
 )
 
+from .json import (
+    json,
+    json_array,
+    json_object,
+    json_extract,
+    json_type,
+    json_valid,
+    json_quote,
+    json_remove,
+    json_set,
+    json_insert,
+    json_replace,
+    json_patch,
+    json_array_length,
+    json_array_unpack,
+    json_object_pack,
+    json_object_retrieve,
+    json_object_length,
+    json_object_keys,
+    json_tree,
+    json_each,
+)
+
+from .math_enhanced import (
+    round_sql,
+    pow,
+    power,
+    sqrt,
+    mod,
+    ceil,
+    floor,
+    trunc,
+    max_sql,
+    min_sql,
+    avg,
+)
+
 __all__ = [
     # String functions
     "substr",
@@ -83,6 +122,18 @@ __all__ = [
     "abs_sql",
     "sign",
     "total",
+    # Math enhanced functions
+    "round_sql",
+    "pow",
+    "power",
+    "sqrt",
+    "mod",
+    "ceil",
+    "floor",
+    "trunc",
+    "max_sql",
+    "min_sql",
+    "avg",
     # Blob functions
     "zeroblob",
     "randomblob",
@@ -93,4 +144,25 @@ __all__ = [
     "changes",
     # Conditional functions
     "iif",
+    # JSON functions
+    "json",
+    "json_array",
+    "json_object",
+    "json_extract",
+    "json_type",
+    "json_valid",
+    "json_quote",
+    "json_remove",
+    "json_set",
+    "json_insert",
+    "json_replace",
+    "json_patch",
+    "json_array_length",
+    "json_array_unpack",
+    "json_object_pack",
+    "json_object_retrieve",
+    "json_object_length",
+    "json_object_keys",
+    "json_tree",
+    "json_each",
 ]

--- a/src/rhosocial/activerecord/backend/impl/sqlite/functions/__init__.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/functions/__init__.py
@@ -85,7 +85,7 @@ from .json import (
 )
 
 from .math_enhanced import (
-    round_sql,
+    round_,
     pow,
     power,
     sqrt,
@@ -93,8 +93,8 @@ from .math_enhanced import (
     ceil,
     floor,
     trunc,
-    max_sql,
-    min_sql,
+    max_,
+    min_,
     avg,
 )
 
@@ -123,7 +123,7 @@ __all__ = [
     "sign",
     "total",
     # Math enhanced functions
-    "round_sql",
+    "round_",
     "pow",
     "power",
     "sqrt",
@@ -131,8 +131,8 @@ __all__ = [
     "ceil",
     "floor",
     "trunc",
-    "max_sql",
-    "min_sql",
+    "max_",
+    "min_",
     "avg",
     # Blob functions
     "zeroblob",

--- a/src/rhosocial/activerecord/backend/impl/sqlite/functions/json.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/functions/json.py
@@ -39,7 +39,13 @@ def _convert_to_expression(
     """
     if isinstance(expr, bases.BaseExpression):
         return expr
-    elif handle_numeric_literals and isinstance(expr, (int, float)):
+    elif isinstance(expr, (int, float)):
+        # Numeric values: convert to Literal if handle_numeric_literals is True
+        if handle_numeric_literals:
+            return core.Literal(dialect, expr)
+        return core.Column(dialect, str(expr))
+    elif isinstance(expr, str):
+        # Strings: always convert to Literal for JSON functions
         return core.Literal(dialect, expr)
     else:
         return core.Column(dialect, expr)

--- a/src/rhosocial/activerecord/backend/impl/sqlite/functions/json.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/functions/json.py
@@ -1,0 +1,687 @@
+# src/rhosocial/activerecord/backend/impl/sqlite/functions/json.py
+"""
+SQLite JSON function factories.
+
+SQLite 3.38+ includes the json1 extension for JSON manipulation.
+These functions provide a consistent API for working with JSON data in SQLite.
+
+Functions: json, json_array, json_object, json_extract, json_type,
+json_valid, json_quote, json_remove, json_set, json_insert, json_replace,
+json_patch, json_array_length, json_array_unpack, json_object_pack,
+json_object_retrieve, json_object_length, json_object_keys, json_tree,
+json_each
+"""
+
+from typing import Union, Optional, Any, TYPE_CHECKING
+
+from rhosocial.activerecord.backend.expression import bases, core
+
+if TYPE_CHECKING:  # pragma: no cover
+    from rhosocial.activerecord.backend.dialect import SQLDialectBase
+    from .dialect import SQLiteDialect
+
+
+def _convert_to_expression(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+    handle_numeric_literals: bool = True,
+) -> "bases.BaseExpression":
+    """
+    Helper function to convert an input value to an appropriate BaseExpression.
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The expression to convert
+        handle_numeric_literals: Whether to treat numeric values as literals
+
+    Returns:
+        A BaseExpression instance
+    """
+    if isinstance(expr, bases.BaseExpression):
+        return expr
+    elif handle_numeric_literals and isinstance(expr, (int, float)):
+        return core.Literal(dialect, expr)
+    else:
+        return core.Column(dialect, expr)
+
+
+def json(
+    dialect: "SQLiteDialect",
+    value: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a JSON function call.
+
+    Validates and converts a value to a JSON literal.
+
+    Usage:
+        - json(dialect, '{"a": 1}') -> JSON('{"a": 1}')
+        - json(dialect, Column(dialect, "data"))
+
+    Args:
+        dialect: The SQLite dialect instance
+        value: Value to convert to JSON
+
+    Returns:
+        A FunctionCall instance representing JSON
+
+    Version: SQLite 3.38.0+
+    """
+    val_expr = _convert_to_expression(dialect, value)
+    return core.FunctionCall(dialect, "JSON", val_expr)
+
+
+def json_array(
+    dialect: "SQLiteDialect",
+    *values: Any,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_ARRAY function call.
+
+    Creates a JSON array from the arguments.
+
+    Usage:
+        - json_array(dialect) -> JSON_ARRAY()
+        - json_array(dialect, 1, 2, 3) -> JSON_ARRAY(1, 2, 3)
+        - json_array(dialect, "a", Column(dialect, "b")) -> JSON_ARRAY('a', "b")
+
+    Args:
+        dialect: The SQLite dialect instance
+        *values: Values to include in the array
+
+    Returns:
+        A FunctionCall instance representing JSON_ARRAY
+
+    Version: SQLite 3.38.0+
+    """
+    if not values:
+        return core.FunctionCall(dialect, "JSON_ARRAY")
+    args = [core.Literal(dialect, v) if not isinstance(v, bases.BaseExpression) else v
+            for v in values]
+    return core.FunctionCall(dialect, "JSON_ARRAY", *args)
+
+
+def json_object(
+    dialect: "SQLiteDialect",
+    *key_value_pairs: Any,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_OBJECT function call.
+
+    Creates a JSON object from key-value pairs.
+
+    Usage:
+        - json_object(dialect) -> JSON_OBJECT()
+        - json_object(dialect, "a", 1, "b", 2) -> JSON_OBJECT('a', 1, 'b', 2)
+
+    Args:
+        dialect: The SQLite dialect instance
+        *key_value_pairs: Alternating keys and values
+
+    Returns:
+        A FunctionCall instance representing JSON_OBJECT
+
+    Version: SQLite 3.38.0+
+    """
+    if not key_value_pairs:
+        return core.FunctionCall(dialect, "JSON_OBJECT")
+    args = [core.Literal(dialect, v) if not isinstance(v, bases.BaseExpression) else v
+            for v in key_value_pairs]
+    return core.FunctionCall(dialect, "JSON_OBJECT", *args)
+
+
+def json_extract(
+    dialect: "SQLiteDialect",
+    json_doc: Union[str, "bases.BaseExpression"],
+    path: str,
+    *paths: str,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_EXTRACT function call.
+
+    Extracts values from a JSON document at the specified path(s).
+
+    Usage:
+        - json_extract(dialect, Column(dialect, "data"), "$.a")
+        - json_extract(dialect, '{"a": 1}', "$.a")
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_doc: JSON document (column or literal)
+        path: First JSON path expression
+        *paths: Additional JSON path expressions
+
+    Returns:
+        A FunctionCall instance representing JSON_EXTRACT
+
+    Version: SQLite 3.38.0+
+    """
+    doc_expr = _convert_to_expression(dialect, json_doc)
+    path_expr = core.Literal(dialect, path)
+    args = [doc_expr, path_expr]
+    for p in paths:
+        args.append(core.Literal(dialect, p))
+    return core.FunctionCall(dialect, "JSON_EXTRACT", *args)
+
+
+def json_type(
+    dialect: "SQLiteDialect",
+    json_val: Union[str, "bases.BaseExpression"],
+    path: Optional[str] = None,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_TYPE function call.
+
+    Returns the type of a JSON value at the specified path.
+
+    Usage:
+        - json_type(dialect, Column(dialect, "data"), "$.a")
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_val: JSON value or column
+        path: Optional path within the JSON
+
+    Returns:
+        A FunctionCall instance representing JSON_TYPE
+
+    Version: SQLite 3.38.0+
+    """
+    val_expr = _convert_to_expression(dialect, json_val)
+    if path is not None:
+        path_expr = core.Literal(dialect, path)
+        return core.FunctionCall(dialect, "JSON_TYPE", val_expr, path_expr)
+    return core.FunctionCall(dialect, "JSON_TYPE", val_expr)
+
+
+def json_valid(
+    dialect: "SQLiteDialect",
+    json_val: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_VALID function call.
+
+    Returns 1 if the value is valid JSON, 0 otherwise.
+
+    Usage:
+        - json_valid(dialect, Column(dialect, "data"))
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_val: Value to validate
+
+    Returns:
+        A FunctionCall instance representing JSON_VALID
+
+    Version: SQLite 3.38.0+
+    """
+    val_expr = _convert_to_expression(dialect, json_val)
+    return core.FunctionCall(dialect, "JSON_VALID", val_expr)
+
+
+def json_quote(
+    dialect: "SQLiteDialect",
+    value: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_QUOTE function call.
+
+    Converts a value to a JSON literal (quoted string or other JSON literal).
+
+    Usage:
+        - json_quote(dialect, "hello") -> JSON_QUOTE('hello')
+
+    Args:
+        dialect: The SQLite dialect instance
+        value: Value to quote as JSON
+
+    Returns:
+        A FunctionCall instance representing JSON_QUOTE
+
+    Version: SQLite 3.38.0+
+    """
+    val_expr = _convert_to_expression(dialect, value)
+    return core.FunctionCall(dialect, "JSON_QUOTE", val_expr)
+
+
+def json_remove(
+    dialect: "SQLiteDialect",
+    json_doc: Union[str, "bases.BaseExpression"],
+    path: str,
+    *paths: str,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_REMOVE function call.
+
+    Removes values from a JSON document at the specified path(s).
+
+    Usage:
+        - json_remove(dialect, Column(dialect, "data"), "$.a")
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_doc: JSON document or column
+        path: First path to remove
+        *paths: Additional paths to remove
+
+    Returns:
+        A FunctionCall instance representing JSON_REMOVE
+
+    Version: SQLite 3.38.0+
+    """
+    doc_expr = _convert_to_expression(dialect, json_doc)
+    path_expr = core.Literal(dialect, path)
+    args = [doc_expr, path_expr]
+    for p in paths:
+        args.append(core.Literal(dialect, p))
+    return core.FunctionCall(dialect, "JSON_REMOVE", *args)
+
+
+def json_set(
+    dialect: "SQLiteDialect",
+    json_doc: Union[str, "bases.BaseExpression"],
+    path: str,
+    value: Any,
+    *path_values: Any,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_SET function call.
+
+    Inserts or replaces values in a JSON document.
+
+    Usage:
+        - json_set(dialect, Column(dialect, "data"), "$.a", "new_value")
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_doc: JSON document or column
+        path: JSON path expression
+        value: Value to set
+        *path_values: Additional path-value pairs
+
+    Returns:
+        A FunctionCall instance representing JSON_SET
+
+    Version: SQLite 3.38.0+
+    """
+    doc_expr = _convert_to_expression(dialect, json_doc)
+    path_expr = core.Literal(dialect, path)
+    val_expr = core.Literal(dialect, value) if not isinstance(value, bases.BaseExpression) else value
+    args = [doc_expr, path_expr, val_expr]
+    for i in range(0, len(path_values), 2):
+        if i + 1 < len(path_values):
+            args.append(core.Literal(dialect, path_values[i]))
+            pv = path_values[i + 1]
+            args.append(core.Literal(dialect, pv) if not isinstance(pv, bases.BaseExpression) else pv)
+    return core.FunctionCall(dialect, "JSON_SET", *args)
+
+
+def json_insert(
+    dialect: "SQLiteDialect",
+    json_doc: Union[str, "bases.BaseExpression"],
+    path: str,
+    value: Any,
+    *path_values: Any,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_INSERT function call.
+
+    Inserts values into a JSON document without replacing existing values.
+
+    Usage:
+        - json_insert(dialect, Column(dialect, "data"), "$.b", "new_value")
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_doc: JSON document or column
+        path: JSON path expression
+        value: Value to insert
+        *path_values: Additional path-value pairs
+
+    Returns:
+        A FunctionCall instance representing JSON_INSERT
+
+    Version: SQLite 3.38.0+
+    """
+    doc_expr = _convert_to_expression(dialect, json_doc)
+    path_expr = core.Literal(dialect, path)
+    val_expr = core.Literal(dialect, value) if not isinstance(value, bases.BaseExpression) else value
+    args = [doc_expr, path_expr, val_expr]
+    for i in range(0, len(path_values), 2):
+        if i + 1 < len(path_values):
+            args.append(core.Literal(dialect, path_values[i]))
+            pv = path_values[i + 1]
+            args.append(core.Literal(dialect, pv) if not isinstance(pv, bases.BaseExpression) else pv)
+    return core.FunctionCall(dialect, "JSON_INSERT", *args)
+
+
+def json_replace(
+    dialect: "SQLiteDialect",
+    json_doc: Union[str, "bases.BaseExpression"],
+    path: str,
+    value: Any,
+    *path_values: Any,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_REPLACE function call.
+
+    Replaces values in a JSON document (only existing paths are replaced).
+
+    Usage:
+        - json_replace(dialect, Column(dialect, "data"), "$.a", "new_value")
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_doc: JSON document or column
+        path: JSON path expression
+        value: Value to replace
+        *path_values: Additional path-value pairs
+
+    Returns:
+        A FunctionCall instance representing JSON_REPLACE
+
+    Version: SQLite 3.38.0+
+    """
+    doc_expr = _convert_to_expression(dialect, json_doc)
+    path_expr = core.Literal(dialect, path)
+    val_expr = core.Literal(dialect, value) if not isinstance(value, bases.BaseExpression) else value
+    args = [doc_expr, path_expr, val_expr]
+    for i in range(0, len(path_values), 2):
+        if i + 1 < len(path_values):
+            args.append(core.Literal(dialect, path_values[i]))
+            pv = path_values[i + 1]
+            args.append(core.Literal(dialect, pv) if not isinstance(pv, bases.BaseExpression) else pv)
+    return core.FunctionCall(dialect, "JSON_REPLACE", *args)
+
+
+def json_patch(
+    dialect: "SQLiteDialect",
+    json_doc: Union[str, "bases.BaseExpression"],
+    patch: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_PATCH function call.
+
+    Applies a JSON patch to a JSON document (RFC 7396).
+
+    Usage:
+        - json_patch(dialect, Column(dialect, "data"), Column(dialect, "patch"))
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_doc: Target JSON document or column
+        patch: JSON patch to apply
+
+    Returns:
+        A FunctionCall instance representing JSON_PATCH
+
+    Version: SQLite 3.38.0+
+    """
+    doc_expr = _convert_to_expression(dialect, json_doc)
+    patch_expr = _convert_to_expression(dialect, patch)
+    return core.FunctionCall(dialect, "JSON_PATCH", doc_expr, patch_expr)
+
+
+def json_array_length(
+    dialect: "SQLiteDialect",
+    json_val: Union[str, "bases.BaseExpression"],
+    path: Optional[str] = None,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_ARRAY_LENGTH function call.
+
+    Returns the number of elements in a JSON array.
+
+    Usage:
+        - json_array_length(dialect, Column(dialect, "data"))
+        - json_array_length(dialect, Column(dialect, "data"), "$.items")
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_val: JSON value or column
+        path: Optional path to array within JSON
+
+    Returns:
+        A FunctionCall instance representing JSON_ARRAY_LENGTH
+
+    Version: SQLite 3.38.0+
+    """
+    val_expr = _convert_to_expression(dialect, json_val)
+    if path is not None:
+        path_expr = core.Literal(dialect, path)
+        return core.FunctionCall(dialect, "JSON_ARRAY_LENGTH", val_expr, path_expr)
+    return core.FunctionCall(dialect, "JSON_ARRAY_LENGTH", val_expr)
+
+
+def json_array_unpack(
+    dialect: "SQLiteDialect",
+    json_val: Union[str, "bases.BaseExpression"],
+    path: Optional[str] = None,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_UNPACK function call (alias for JSON_ARRAY_LENGTH).
+
+    Note: This function is an alias for extracting array elements.
+
+    Usage:
+        - json_array_unpack(dialect, Column(dialect, "data"))
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_val: JSON value or column
+        path: Optional path to array within JSON
+
+    Returns:
+        A FunctionCall instance representing JSON_UNPACK
+
+    Version: SQLite 3.38.0+
+    """
+    # SQLite doesn't have JSON_UNPACK, this would typically be used with json_each
+    val_expr = _convert_to_expression(dialect, json_val)
+    if path is not None:
+        path_expr = core.Literal(dialect, path)
+        return core.FunctionCall(dialect, "JSON_ARRAY_LENGTH", val_expr, path_expr)
+    return core.FunctionCall(dialect, "JSON_ARRAY_LENGTH", val_expr)
+
+
+def json_object_pack(
+    dialect: "SQLiteDialect",
+    key: str,
+    value: Any,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_OBJECT function call with a single key-value pair.
+
+    This is a convenience function for creating single-entry JSON objects.
+
+    Usage:
+        - json_object_pack(dialect, "key", "value")
+
+    Args:
+        dialect: The SQLite dialect instance
+        key: Object key
+        value: Object value
+
+    Returns:
+        A FunctionCall instance representing JSON_OBJECT
+
+    Version: SQLite 3.38.0+
+    """
+    key_expr = core.Literal(dialect, key)
+    val_expr = core.Literal(dialect, value) if not isinstance(value, bases.BaseExpression) else value
+    return core.FunctionCall(dialect, "JSON_OBJECT", key_expr, val_expr)
+
+
+def json_object_retrieve(
+    dialect: "SQLiteDialect",
+    json_val: Union[str, "bases.BaseExpression"],
+    path: str,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_EXTRACT function call for retrieving a single value.
+
+    This is an alias for json_extract with a single path.
+
+    Usage:
+        - json_object_retrieve(dialect, Column(dialect, "data"), "$.name")
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_val: JSON value or column
+        path: JSON path to retrieve
+
+    Returns:
+        A FunctionCall instance representing JSON_EXTRACT
+
+    Version: SQLite 3.38.0+
+    """
+    val_expr = _convert_to_expression(dialect, json_val)
+    path_expr = core.Literal(dialect, path)
+    return core.FunctionCall(dialect, "JSON_EXTRACT", val_expr, path_expr)
+
+
+def json_object_length(
+    dialect: "SQLiteDialect",
+    json_val: Union[str, "bases.BaseExpression"],
+    path: Optional[str] = None,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_OBJECT_LENGTH function call.
+
+    Returns the number of key-value pairs in a JSON object.
+
+    Usage:
+        - json_object_length(dialect, Column(dialect, "data"))
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_val: JSON value or column
+        path: Optional path within JSON
+
+    Returns:
+        A FunctionCall instance representing JSON_OBJECT_LENGTH
+
+    Version: SQLite 3.38.0+
+    """
+    val_expr = _convert_to_expression(dialect, json_val)
+    if path is not None:
+        path_expr = core.Literal(dialect, path)
+        return core.FunctionCall(dialect, "JSON_OBJECT_LENGTH", val_expr, path_expr)
+    return core.FunctionCall(dialect, "JSON_OBJECT_LENGTH", val_expr)
+
+
+def json_object_keys(
+    dialect: "SQLiteDialect",
+    json_val: Union[str, "bases.BaseExpression"],
+    path: Optional[str] = None,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_OBJECT_KEYS function call.
+
+    Returns the keys of a JSON object as a JSON array.
+
+    Usage:
+        - json_object_keys(dialect, Column(dialect, "data"))
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_val: JSON value or column
+        path: Optional path within JSON
+
+    Returns:
+        A FunctionCall instance representing JSON_OBJECT_KEYS
+
+    Version: SQLite 3.38.0+
+    """
+    val_expr = _convert_to_expression(dialect, json_val)
+    if path is not None:
+        path_expr = core.Literal(dialect, path)
+        return core.FunctionCall(dialect, "JSON_OBJECT_KEYS", val_expr, path_expr)
+    return core.FunctionCall(dialect, "JSON_OBJECT_KEYS", val_expr)
+
+
+def json_tree(
+    dialect: "SQLiteDialect",
+    json_val: Union[str, "bases.BaseExpression"],
+    path: Optional[str] = None,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_TREE function call.
+
+    Returns a virtual table with one row for each element in a JSON array or object.
+
+    Usage:
+        - json_tree(dialect, Column(dialect, "data"))
+        - json_tree(dialect, Column(dialect, "data"), "$.items")
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_val: JSON value or column
+        path: Optional path within JSON
+
+    Returns:
+        A FunctionCall instance representing JSON_TREE
+
+    Version: SQLite 3.38.0+
+    """
+    val_expr = _convert_to_expression(dialect, json_val)
+    if path is not None:
+        path_expr = core.Literal(dialect, path)
+        return core.FunctionCall(dialect, "JSON_TREE", val_expr, path_expr)
+    return core.FunctionCall(dialect, "JSON_TREE", val_expr)
+
+
+def json_each(
+    dialect: "SQLiteDialect",
+    json_val: Union[str, "bases.BaseExpression"],
+    path: Optional[str] = None,
+) -> "core.FunctionCall":
+    """
+    Creates a JSON_EACH function call.
+
+    Returns a virtual table with one row for each element in a JSON array or object.
+    Unlike JSON_TREE, JSON_EACH only iterates over the top-level array or object.
+
+    Usage:
+        - json_each(dialect, Column(dialect, "data"))
+        - json_each(dialect, Column(dialect, "data"), "$.items")
+
+    Args:
+        dialect: The SQLite dialect instance
+        json_val: JSON value or column
+        path: Optional path within JSON
+
+    Returns:
+        A FunctionCall instance representing JSON_EACH
+
+    Version: SQLite 3.38.0+
+    """
+    val_expr = _convert_to_expression(dialect, json_val)
+    if path is not None:
+        path_expr = core.Literal(dialect, path)
+        return core.FunctionCall(dialect, "JSON_EACH", val_expr, path_expr)
+    return core.FunctionCall(dialect, "JSON_EACH", val_expr)
+
+
+__all__ = [
+    "json",
+    "json_array",
+    "json_object",
+    "json_extract",
+    "json_type",
+    "json_valid",
+    "json_quote",
+    "json_remove",
+    "json_set",
+    "json_insert",
+    "json_replace",
+    "json_patch",
+    "json_array_length",
+    "json_array_unpack",
+    "json_object_pack",
+    "json_object_retrieve",
+    "json_object_length",
+    "json_object_keys",
+    "json_tree",
+    "json_each",
+]

--- a/src/rhosocial/activerecord/backend/impl/sqlite/functions/math_enhanced.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/functions/math_enhanced.py
@@ -5,7 +5,7 @@ SQLite enhanced math function factories.
 Additional mathematical functions beyond the basic math module.
 Includes: round, pow, power, sqrt, mod, ceil, floor, truncate, max, min, avg
 
-Functions: round_sql, pow, power, sqrt, mod, ceil, floor, trunc, max_sql, min_sql, avg
+Functions: round_, pow, power, sqrt, mod, ceil, floor, trunc, max_, min_, avg
 """
 
 from typing import Union, TYPE_CHECKING
@@ -45,7 +45,7 @@ def _convert_to_expression(
         return core.Column(dialect, expr)
 
 
-def round_sql(
+def round_(
     dialect: "SQLDialectBase",
     expr: Union[str, "bases.BaseExpression"],
     precision: int = 0,
@@ -56,8 +56,8 @@ def round_sql(
     Rounds a numeric value to the specified number of decimal places.
 
     Usage:
-        - round_sql(dialect, Column("price")) -> ROUND("price")
-        - round_sql(dialect, Column("price"), 2) -> ROUND("price", 2)
+        - round_(dialect, Column("price")) -> ROUND("price")
+        - round_(dialect, Column("price"), 2) -> ROUND("price", 2)
 
     Args:
         dialect: The SQL dialect instance
@@ -249,7 +249,7 @@ def trunc(
     return core.FunctionCall(dialect, "TRUNC", target_expr)
 
 
-def max_sql(
+def max_(
     dialect: "SQLDialectBase",
     expr1: Union[str, "bases.BaseExpression"],
     expr2: Union[str, "bases.BaseExpression"],
@@ -261,8 +261,8 @@ def max_sql(
     Returns the maximum value among the arguments.
 
     Usage:
-        - max_sql(dialect, 1, 2) -> MAX(1, 2)
-        - max_sql(dialect, Column("a"), Column("b")) -> MAX("a", "b")
+        - max_(dialect, 1, 2) -> MAX(1, 2)
+        - max_(dialect, Column("a"), Column("b")) -> MAX("a", "b")
 
     Args:
         dialect: The SQL dialect instance
@@ -279,7 +279,7 @@ def max_sql(
     return core.FunctionCall(dialect, "MAX", *exprs)
 
 
-def min_sql(
+def min_(
     dialect: "SQLDialectBase",
     expr1: Union[str, "bases.BaseExpression"],
     expr2: Union[str, "bases.BaseExpression"],
@@ -291,8 +291,8 @@ def min_sql(
     Returns the minimum value among the arguments.
 
     Usage:
-        - min_sql(dialect, 1, 2) -> MIN(1, 2)
-        - min_sql(dialect, Column("a"), Column("b")) -> MIN("a", "b")
+        - min_(dialect, 1, 2) -> MIN(1, 2)
+        - min_(dialect, Column("a"), Column("b")) -> MIN("a", "b")
 
     Args:
         dialect: The SQL dialect instance
@@ -333,7 +333,7 @@ def avg(
 
 
 __all__ = [
-    "round_sql",
+    "round_",
     "pow",
     "power",
     "sqrt",
@@ -341,7 +341,7 @@ __all__ = [
     "ceil",
     "floor",
     "trunc",
-    "max_sql",
-    "min_sql",
+    "max_",
+    "min_",
     "avg",
 ]

--- a/src/rhosocial/activerecord/backend/impl/sqlite/functions/math_enhanced.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/functions/math_enhanced.py
@@ -32,7 +32,17 @@ def _convert_to_expression(
     """
     if isinstance(expr, bases.BaseExpression):
         return expr
-    return core.Column(dialect, expr)
+    elif isinstance(expr, (int, float)):
+        return core.Literal(dialect, expr)
+    elif isinstance(expr, str):
+        # Try to parse as number first
+        try:
+            return core.Literal(dialect, float(expr) if '.' in expr else int(expr))
+        except ValueError:
+            # Not a number, treat as column name
+            return core.Column(dialect, expr)
+    else:
+        return core.Column(dialect, expr)
 
 
 def round_sql(

--- a/src/rhosocial/activerecord/backend/impl/sqlite/functions/math_enhanced.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/functions/math_enhanced.py
@@ -1,0 +1,337 @@
+# src/rhosocial/activerecord/backend/impl/sqlite/functions/math_enhanced.py
+"""
+SQLite enhanced math function factories.
+
+Additional mathematical functions beyond the basic math module.
+Includes: round, pow, power, sqrt, mod, ceil, floor, truncate, max, min, avg
+
+Functions: round_sql, pow, power, sqrt, mod, ceil, floor, trunc, max_sql, min_sql, avg
+"""
+
+from typing import Union, TYPE_CHECKING
+
+from rhosocial.activerecord.backend.expression import bases, core
+
+if TYPE_CHECKING:  # pragma: no cover
+    from rhosocial.activerecord.backend.dialect import SQLDialectBase
+
+
+def _convert_to_expression(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+) -> "bases.BaseExpression":
+    """
+    Helper function to convert an input value to an appropriate BaseExpression.
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The expression to convert
+
+    Returns:
+        A BaseExpression instance
+    """
+    if isinstance(expr, bases.BaseExpression):
+        return expr
+    return core.Column(dialect, expr)
+
+
+def round_sql(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+    precision: int = 0,
+) -> "core.FunctionCall":
+    """
+    Creates a ROUND function call.
+
+    Rounds a numeric value to the specified number of decimal places.
+
+    Usage:
+        - round_sql(dialect, Column("price")) -> ROUND("price")
+        - round_sql(dialect, Column("price"), 2) -> ROUND("price", 2)
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The numeric expression to round
+        precision: Number of decimal places (default 0)
+
+    Returns:
+        A FunctionCall instance representing the ROUND function
+    """
+    target_expr = _convert_to_expression(dialect, expr)
+    precision_expr = core.Literal(dialect, precision)
+    return core.FunctionCall(dialect, "ROUND", target_expr, precision_expr)
+
+
+def pow(
+    dialect: "SQLDialectBase",
+    base: Union[str, "bases.BaseExpression"],
+    exponent: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a POW function call.
+
+    Returns the value of base raised to the power of exponent.
+
+    Usage:
+        - pow(dialect, 2, 3) -> POW(2, 3)
+        - pow(dialect, Column("x"), 2) -> POW("x", 2)
+
+    Args:
+        dialect: The SQL dialect instance
+        base: The base value
+        exponent: The exponent value
+
+    Returns:
+        A FunctionCall instance representing the POW function
+    """
+    base_expr = _convert_to_expression(dialect, base)
+    exp_expr = _convert_to_expression(dialect, exponent)
+    return core.FunctionCall(dialect, "POW", base_expr, exp_expr)
+
+
+def power(
+    dialect: "SQLDialectBase",
+    base: Union[str, "bases.BaseExpression"],
+    exponent: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a POWER function call (alias for POW).
+
+    Returns the value of base raised to the power of exponent.
+
+    Usage:
+        - power(dialect, 2, 3) -> POWER(2, 3)
+        - power(dialect, Column("x"), 2) -> POWER("x", 2)
+
+    Args:
+        dialect: The SQL dialect instance
+        base: The base value
+        exponent: The exponent value
+
+    Returns:
+        A FunctionCall instance representing the POWER function
+    """
+    base_expr = _convert_to_expression(dialect, base)
+    exp_expr = _convert_to_expression(dialect, exponent)
+    return core.FunctionCall(dialect, "POWER", base_expr, exp_expr)
+
+
+def sqrt(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a SQRT function call.
+
+    Returns the square root of the argument.
+
+    Usage:
+        - sqrt(dialect, 16) -> SQRT(16)
+        - sqrt(dialect, Column("value")) -> SQRT("value")
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The numeric expression
+
+    Returns:
+        A FunctionCall instance representing the SQRT function
+    """
+    target_expr = _convert_to_expression(dialect, expr)
+    return core.FunctionCall(dialect, "SQRT", target_expr)
+
+
+def mod(
+    dialect: "SQLDialectBase",
+    dividend: Union[str, "bases.BaseExpression"],
+    divisor: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a MOD function call.
+
+    Returns the remainder of dividend divided by divisor.
+
+    Usage:
+        - mod(dialect, 10, 3) -> MOD(10, 3)
+        - mod(dialect, Column("total"), Column("count")) -> MOD("total", "count")
+
+    Args:
+        dialect: The SQL dialect instance
+        dividend: The dividend value
+        divisor: The divisor value
+
+    Returns:
+        A FunctionCall instance representing the MOD function
+    """
+    dividend_expr = _convert_to_expression(dialect, dividend)
+    divisor_expr = _convert_to_expression(dialect, divisor)
+    return core.FunctionCall(dialect, "MOD", dividend_expr, divisor_expr)
+
+
+def ceil(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a CEIL function call (SQLite 3.44.0+).
+
+    Returns the smallest integer greater than or equal to the argument.
+
+    Usage:
+        - ceil(dialect, 3.14) -> CEIL(3.14)
+        - ceil(dialect, Column("value")) -> CEIL("value")
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The numeric expression
+
+    Returns:
+        A FunctionCall instance representing the CEIL function
+    """
+    target_expr = _convert_to_expression(dialect, expr)
+    return core.FunctionCall(dialect, "CEIL", target_expr)
+
+
+def floor(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a FLOOR function call (SQLite 3.44.0+).
+
+    Returns the largest integer less than or equal to the argument.
+
+    Usage:
+        - floor(dialect, 3.14) -> FLOOR(3.14)
+        - floor(dialect, Column("value")) -> FLOOR("value")
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The numeric expression
+
+    Returns:
+        A FunctionCall instance representing the FLOOR function
+    """
+    target_expr = _convert_to_expression(dialect, expr)
+    return core.FunctionCall(dialect, "FLOOR", target_expr)
+
+
+def trunc(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a TRUNC function call.
+
+    Returns the integer part of a number (truncates toward zero).
+
+    Usage:
+        - trunc(dialect, 3.14) -> TRUNC(3.14)
+        - trunc(dialect, Column("value")) -> TRUNC("value")
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The numeric expression
+
+    Returns:
+        A FunctionCall instance representing the TRUNC function
+    """
+    target_expr = _convert_to_expression(dialect, expr)
+    return core.FunctionCall(dialect, "TRUNC", target_expr)
+
+
+def max_sql(
+    dialect: "SQLDialectBase",
+    expr1: Union[str, "bases.BaseExpression"],
+    expr2: Union[str, "bases.BaseExpression"],
+    *more: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a MAX function call.
+
+    Returns the maximum value among the arguments.
+
+    Usage:
+        - max_sql(dialect, 1, 2) -> MAX(1, 2)
+        - max_sql(dialect, Column("a"), Column("b")) -> MAX("a", "b")
+
+    Args:
+        dialect: The SQL dialect instance
+        expr1: First expression
+        expr2: Second expression
+        *more: Additional expressions
+
+    Returns:
+        A FunctionCall instance representing the MAX function
+    """
+    exprs = [_convert_to_expression(dialect, expr1), _convert_to_expression(dialect, expr2)]
+    for m in more:
+        exprs.append(_convert_to_expression(dialect, m))
+    return core.FunctionCall(dialect, "MAX", *exprs)
+
+
+def min_sql(
+    dialect: "SQLDialectBase",
+    expr1: Union[str, "bases.BaseExpression"],
+    expr2: Union[str, "bases.BaseExpression"],
+    *more: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a MIN function call.
+
+    Returns the minimum value among the arguments.
+
+    Usage:
+        - min_sql(dialect, 1, 2) -> MIN(1, 2)
+        - min_sql(dialect, Column("a"), Column("b")) -> MIN("a", "b")
+
+    Args:
+        dialect: The SQL dialect instance
+        expr1: First expression
+        expr2: Second expression
+        *more: Additional expressions
+
+    Returns:
+        A FunctionCall instance representing the MIN function
+    """
+    exprs = [_convert_to_expression(dialect, expr1), _convert_to_expression(dialect, expr2)]
+    for m in more:
+        exprs.append(_convert_to_expression(dialect, m))
+    return core.FunctionCall(dialect, "MIN", *exprs)
+
+
+def avg(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates an AVG aggregate function call.
+
+    Returns the average value of all non-NULL values in a group.
+
+    Usage:
+        - avg(dialect, Column("price")) -> AVG("price")
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The expression to average
+
+    Returns:
+        A FunctionCall instance representing the AVG function
+    """
+    target_expr = _convert_to_expression(dialect, expr)
+    return core.FunctionCall(dialect, "AVG", target_expr)
+
+
+__all__ = [
+    "round_sql",
+    "pow",
+    "power",
+    "sqrt",
+    "mod",
+    "ceil",
+    "floor",
+    "trunc",
+    "max_sql",
+    "min_sql",
+    "avg",
+]

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite/test_transaction.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite/test_transaction.py
@@ -1,6 +1,7 @@
 # tests/rhosocial/activerecord_test/feature/backend/sqlite/test_transaction.py
 import logging
 import sqlite3
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -84,6 +85,12 @@ class TestSQLiteTransactionManager:
 
     def test_log_method(self, transaction_manager):
         """Test log method"""
+        # Use a dedicated logger to avoid interference from GC-triggered
+        # disconnect calls on other backend instances sharing the same
+        # singleton logger. When __del__ fires on a stale backend during GC,
+        # its disconnect() logs through the shared logger, polluting the mock.
+        dedicated_logger = logging.getLogger(f"test_log_method_{uuid.uuid4().hex}")
+        transaction_manager._logger = dedicated_logger
         with patch.object(transaction_manager._logger, 'log') as mock_log:
             transaction_manager.log(logging.INFO, "Test message")
             mock_log.assert_called_once_with(logging.INFO, "Test message")

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_functions_integration.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_functions_integration.py
@@ -66,7 +66,7 @@ class TestMathFunctionsIntegration:
         )
         assert query_result.data[0]["result"] == 4.0
 
-    def test_round_sql_execution(self, sqlite_backend_with_data):
+    def test_round__execution(self, sqlite_backend_with_data):
         """Test ROUND function execution."""
         backend, dialect = sqlite_backend_with_data
 
@@ -173,7 +173,7 @@ class TestMathFunctionsIntegration:
         )
         assert query_result.data[0]["result"] == 3.0
 
-    def test_max_sql_execution(self, sqlite_backend_with_data):
+    def test_max__execution(self, sqlite_backend_with_data):
         """Test MAX function execution."""
         backend, dialect = sqlite_backend_with_data
 
@@ -188,7 +188,7 @@ class TestMathFunctionsIntegration:
         )
         assert query_result.data[0]["result"] == 9
 
-    def test_min_sql_execution(self, sqlite_backend_with_data):
+    def test_min__execution(self, sqlite_backend_with_data):
         """Test MIN function execution."""
         backend, dialect = sqlite_backend_with_data
 

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_functions_integration.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_functions_integration.py
@@ -1,0 +1,437 @@
+# tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_functions_integration.py
+"""
+Integration tests for SQLite math and JSON functions.
+
+These tests execute SQL functions against an actual SQLite database
+and verify the results match expected values.
+"""
+import pytest
+from rhosocial.activerecord.backend.expression import Column, Literal, FunctionCall, QueryExpression
+from rhosocial.activerecord.backend.options import ExecutionOptions
+from rhosocial.activerecord.backend.schema import StatementType
+from rhosocial.activerecord.backend.impl.sqlite.dialect import SQLiteDialect
+from rhosocial.activerecord.backend.impl.sqlite.backend import SQLiteBackend
+
+
+@pytest.fixture
+def sqlite_backend_with_data():
+    """Provides a SQLiteBackend connected to an in-memory database with test data."""
+    backend = SQLiteBackend(database=":memory:")
+    backend.connect()
+    dialect = backend.dialect
+
+    # Create a test table
+    backend.execute(
+        "CREATE TABLE test_data (id INTEGER PRIMARY KEY, value REAL, text TEXT, json_data TEXT)",
+        (),
+        options=ExecutionOptions(stmt_type=StatementType.DDL)
+    )
+
+    # Insert test data
+    backend.execute(
+        "INSERT INTO test_data (value, text, json_data) VALUES (?, ?, ?)",
+        (16.0, "hello", '{"a": 1, "b": 2}'),
+        options=ExecutionOptions(stmt_type=StatementType.DML)
+    )
+    backend.execute(
+        "INSERT INTO test_data (value, text, json_data) VALUES (?, ?, ?)",
+        (25.0, "world", '{"a": 3, "b": 4}'),
+        options=ExecutionOptions(stmt_type=StatementType.DML)
+    )
+    backend.execute(
+        "INSERT INTO test_data (value, text, json_data) VALUES (?, ?, ?)",
+        (100.0, "test", '[1, 2, 3]'),
+        options=ExecutionOptions(stmt_type=StatementType.DML)
+    )
+
+    yield backend, dialect
+    backend.disconnect()
+
+
+class TestMathFunctionsIntegration:
+    """Integration tests for SQLite math functions with actual execution."""
+
+    def test_sqrt_execution(self, sqlite_backend_with_data):
+        """Test SQRT function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "SQRT", Literal(dialect, 16)).as_("result")
+        query = QueryExpression(dialect, select=[result])
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == 4.0
+
+    def test_round_sql_execution(self, sqlite_backend_with_data):
+        """Test ROUND function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "ROUND", Column(dialect, "value"), Literal(dialect, 1)).as_("rounded")
+        query = QueryExpression(dialect, select=[result, Column(dialect, "value")], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["rounded"] == 16.0
+
+    def test_pow_execution(self, sqlite_backend_with_data):
+        """Test POW function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "POW", Column(dialect, "value"), Literal(dialect, 2)).as_("powered")
+        query = QueryExpression(dialect, select=[result, Column(dialect, "value")], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["powered"] == 256.0
+        assert query_result.data[1]["powered"] == 625.0
+
+    def test_power_execution(self, sqlite_backend_with_data):
+        """Test POWER function execution (alias for POW)."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "POWER", Literal(dialect, 2), Literal(dialect, 3)).as_("result")
+        query = QueryExpression(dialect, select=[result])
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == 8.0
+
+    def test_mod_execution(self, sqlite_backend_with_data):
+        """Test MOD function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "MOD", Column(dialect, "value"), Literal(dialect, 10)).as_("modded")
+        query = QueryExpression(dialect, select=[result, Column(dialect, "value")], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["modded"] == 6.0
+        assert query_result.data[1]["modded"] == 5.0
+
+    def test_ceil_execution(self, sqlite_backend_with_data):
+        """Test CEIL function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "CEIL", Literal(dialect, 3.14)).as_("result")
+        query = QueryExpression(dialect, select=[result])
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == 4.0
+
+    def test_floor_execution(self, sqlite_backend_with_data):
+        """Test FLOOR function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "FLOOR", Literal(dialect, 3.14)).as_("result")
+        query = QueryExpression(dialect, select=[result])
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == 3.0
+
+    def test_trunc_execution(self, sqlite_backend_with_data):
+        """Test TRUNC function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "TRUNC", Literal(dialect, 3.14)).as_("result")
+        query = QueryExpression(dialect, select=[result])
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == 3.0
+
+    def test_max_sql_execution(self, sqlite_backend_with_data):
+        """Test MAX function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "MAX", Literal(dialect, 1), Literal(dialect, 5), Literal(dialect, 3), Literal(dialect, 9), Literal(dialect, 2)).as_("result")
+        query = QueryExpression(dialect, select=[result])
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == 9
+
+    def test_min_sql_execution(self, sqlite_backend_with_data):
+        """Test MIN function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "MIN", Literal(dialect, 1), Literal(dialect, 5), Literal(dialect, 3), Literal(dialect, 9), Literal(dialect, 2)).as_("result")
+        query = QueryExpression(dialect, select=[result])
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == 1
+
+    def test_avg_execution(self, sqlite_backend_with_data):
+        """Test AVG function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "AVG", Column(dialect, "value")).as_("avg_value")
+        query = QueryExpression(dialect, select=[result], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["avg_value"] == 47.0
+
+
+class TestJSONFunctionsIntegration:
+    """Integration tests for SQLite JSON functions with actual execution."""
+
+    def test_json_function_execution(self, sqlite_backend_with_data):
+        """Test JSON function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON", Literal(dialect, '{"a": 1}')).as_("result")
+        query = QueryExpression(dialect, select=[result])
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == '{"a":1}'
+
+    def test_json_array_execution(self, sqlite_backend_with_data):
+        """Test JSON_ARRAY function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_ARRAY", Literal(dialect, 1), Literal(dialect, 2), Literal(dialect, 3)).as_("result")
+        query = QueryExpression(dialect, select=[result])
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == '[1,2,3]'
+
+    def test_json_object_execution(self, sqlite_backend_with_data):
+        """Test JSON_OBJECT function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_OBJECT", Literal(dialect, "a"), Literal(dialect, 1), Literal(dialect, "b"), Literal(dialect, 2)).as_("result")
+        query = QueryExpression(dialect, select=[result])
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == '{"a":1,"b":2}'
+
+    def test_json_extract_execution(self, sqlite_backend_with_data):
+        """Test JSON_EXTRACT function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_EXTRACT", Column(dialect, "json_data"), Literal(dialect, "$.a")).as_("extracted")
+        query = QueryExpression(dialect, select=[result], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["extracted"] == 1
+        assert query_result.data[1]["extracted"] == 3
+
+    def test_json_type_execution(self, sqlite_backend_with_data):
+        """Test JSON_TYPE function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_TYPE", Column(dialect, "json_data"), Literal(dialect, "$.a")).as_("result")
+        query = QueryExpression(dialect, select=[result], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == 'integer'
+
+    def test_json_valid_execution(self, sqlite_backend_with_data):
+        """Test JSON_VALID function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_VALID", Column(dialect, "json_data")).as_("valid")
+        query = QueryExpression(dialect, select=[result, Column(dialect, "json_data")], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["valid"] == 1
+        assert query_result.data[2]["valid"] == 1
+
+    def test_json_quote_execution(self, sqlite_backend_with_data):
+        """Test JSON_QUOTE function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_QUOTE", Literal(dialect, "hello")).as_("result")
+        query = QueryExpression(dialect, select=[result])
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == '"hello"'
+
+    def test_json_remove_execution(self, sqlite_backend_with_data):
+        """Test JSON_REMOVE function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_REMOVE", Column(dialect, "json_data"), Literal(dialect, "$.a")).as_("removed")
+        query = QueryExpression(dialect, select=[result], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["removed"] == '{"b":2}'
+
+    def test_json_set_execution(self, sqlite_backend_with_data):
+        """Test JSON_SET function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_SET", Column(dialect, "json_data"), Literal(dialect, "$.c"), Literal(dialect, 3)).as_("result")
+        query = QueryExpression(dialect, select=[result], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == '{"a":1,"b":2,"c":3}'
+
+    def test_json_insert_execution(self, sqlite_backend_with_data):
+        """Test JSON_INSERT function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_INSERT", Column(dialect, "json_data"), Literal(dialect, "$.c"), Literal(dialect, 3)).as_("result")
+        query = QueryExpression(dialect, select=[result], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == '{"a":1,"b":2,"c":3}'
+
+    def test_json_replace_execution(self, sqlite_backend_with_data):
+        """Test JSON_REPLACE function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_REPLACE", Column(dialect, "json_data"), Literal(dialect, "$.a"), Literal(dialect, 10)).as_("result")
+        query = QueryExpression(dialect, select=[result], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == '{"a":10,"b":2}'
+
+    def test_json_patch_execution(self, sqlite_backend_with_data):
+        """Test JSON_PATCH function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_PATCH", Column(dialect, "json_data"), Literal(dialect, '{"a": 10}')).as_("result")
+        query = QueryExpression(dialect, select=[result], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["result"] == '{"a":10,"b":2}'
+
+    def test_json_array_length_execution(self, sqlite_backend_with_data):
+        """Test JSON_ARRAY_LENGTH function execution."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_ARRAY_LENGTH", Column(dialect, "json_data")).as_("length")
+        query = QueryExpression(dialect, select=[result], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["length"] == 0  # object has 0 array elements
+        assert query_result.data[2]["length"] == 3  # array has length 3
+
+    def test_json_object_retrieve_execution(self, sqlite_backend_with_data):
+        """Test json_object_retrieve function execution (uses JSON_EXTRACT internally)."""
+        backend, dialect = sqlite_backend_with_data
+
+        result = FunctionCall(dialect, "JSON_EXTRACT", Column(dialect, "json_data"), Literal(dialect, "$.a")).as_("retrieved")
+        query = QueryExpression(dialect, select=[result], from_="test_data")
+        sql, params = query.to_sql()
+
+        query_result = backend.execute(
+            sql,
+            params,
+            options=ExecutionOptions(stmt_type=StatementType.DQL),
+        )
+        assert query_result.data[0]["retrieved"] == 1
+        assert query_result.data[1]["retrieved"] == 3

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_json_functions.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_json_functions.py
@@ -1,0 +1,370 @@
+# tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_json_functions.py
+"""
+Tests for SQLite-specific JSON functions.
+These functions are available in SQLite 3.38.0+ with the json1 extension.
+"""
+from rhosocial.activerecord.backend.expression import Column
+from rhosocial.activerecord.backend.impl.sqlite.dialect import SQLiteDialect
+from rhosocial.activerecord.backend.impl.sqlite.functions.json import (
+    json,
+    json_array,
+    json_object,
+    json_extract,
+    json_type,
+    json_valid,
+    json_quote,
+    json_remove,
+    json_set,
+    json_insert,
+    json_replace,
+    json_patch,
+    json_array_length,
+    json_array_unpack,
+    json_object_pack,
+    json_object_retrieve,
+    json_object_length,
+    json_object_keys,
+    json_tree,
+    json_each,
+)
+
+
+class TestSQLiteJSONFunctions:
+    """Tests for SQLite JSON functions."""
+
+    def test_json_with_string(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json() with string literal."""
+        result = json(sqlite_dialect_3_38_0, '{"a": 1}')
+        sql, params = result.to_sql()
+        assert "JSON(" in sql
+        assert params == ('{"a": 1}',)
+
+    def test_json_with_column(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json() with column reference."""
+        col = Column(sqlite_dialect_3_38_0, "data")
+        result = json(sqlite_dialect_3_38_0, col)
+        sql, _ = result.to_sql()
+        assert "JSON(" in sql
+        assert '"data"' in sql
+
+    def test_json_array_empty(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_array() with no arguments."""
+        result = json_array(sqlite_dialect_3_38_0)
+        sql, _ = result.to_sql()
+        assert "JSON_ARRAY()" in sql
+
+    def test_json_array_with_values(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_array() with values."""
+        result = json_array(sqlite_dialect_3_38_0, 1, 2, 3)
+        sql, params = result.to_sql()
+        assert "JSON_ARRAY(" in sql
+        assert params == (1, 2, 3)
+
+    def test_json_array_with_mixed(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_array() with mixed types."""
+        result = json_array(sqlite_dialect_3_38_0, "hello", 123, Column(sqlite_dialect_3_38_0, "col"))
+        sql, params = result.to_sql()
+        assert "JSON_ARRAY(" in sql
+        assert params == ("hello", 123)
+
+    def test_json_object_empty(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_object() with no arguments."""
+        result = json_object(sqlite_dialect_3_38_0)
+        sql, _ = result.to_sql()
+        assert "JSON_OBJECT()" in sql
+
+    def test_json_object_with_pairs(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_object() with key-value pairs."""
+        result = json_object(sqlite_dialect_3_38_0, "name", "John", "age", 30)
+        sql, params = result.to_sql()
+        assert "JSON_OBJECT(" in sql
+        assert params == ("name", "John", "age", 30)
+
+    def test_json_extract(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_extract() with path."""
+        result = json_extract(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"), "$.a")
+        sql, params = result.to_sql()
+        assert "JSON_EXTRACT(" in sql
+        assert params == ("$.a",)
+
+    def test_json_extract_multiple_paths(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_extract() with multiple paths."""
+        result = json_extract(
+            sqlite_dialect_3_38_0,
+            '{"a": 1}',
+            "$.a",
+            "$.b"
+        )
+        sql, params = result.to_sql()
+        assert "JSON_EXTRACT(" in sql
+        assert params == ('{"a": 1}', "$.a", "$.b")
+
+    def test_json_type(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_type() without path."""
+        result = json_type(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"))
+        sql, _ = result.to_sql()
+        assert "JSON_TYPE(" in sql
+
+    def test_json_type_with_path(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_type() with path."""
+        result = json_type(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"), "$.a")
+        sql, params = result.to_sql()
+        assert "JSON_TYPE(" in sql
+        assert params == ("$.a",)
+
+    def test_json_valid_true(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_valid() with valid JSON."""
+        result = json_valid(sqlite_dialect_3_38_0, '{"a": 1}')
+        sql, params = result.to_sql()
+        assert "JSON_VALID(" in sql
+        assert params == ('{"a": 1}',)
+
+    def test_json_valid_with_column(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_valid() with column reference."""
+        result = json_valid(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"))
+        sql, _ = result.to_sql()
+        assert "JSON_VALID(" in sql
+
+    def test_json_quote(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_quote()."""
+        result = json_quote(sqlite_dialect_3_38_0, "hello")
+        sql, params = result.to_sql()
+        assert "JSON_QUOTE(" in sql
+        assert params == ("hello",)
+
+    def test_json_remove(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_remove()."""
+        result = json_remove(
+            sqlite_dialect_3_38_0,
+            Column(sqlite_dialect_3_38_0, "data"),
+            "$.a"
+        )
+        sql, params = result.to_sql()
+        assert "JSON_REMOVE(" in sql
+        assert params == ("$.a",)
+
+    def test_json_remove_multiple_paths(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_remove() with multiple paths."""
+        result = json_remove(
+            sqlite_dialect_3_38_0,
+            '{"a": 1, "b": 2}',
+            "$.a",
+            "$.b"
+        )
+        sql, params = result.to_sql()
+        assert "JSON_REMOVE(" in sql
+        assert params == ('{"a": 1, "b": 2}', "$.a", "$.b")
+
+    def test_json_set(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_set()."""
+        result = json_set(
+            sqlite_dialect_3_38_0,
+            Column(sqlite_dialect_3_38_0, "data"),
+            "$.a",
+            "new_value"
+        )
+        sql, params = result.to_sql()
+        assert "JSON_SET(" in sql
+        assert params == ("$.a", "new_value")
+
+    def test_json_set_multiple_pairs(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_set() with multiple path-value pairs."""
+        result = json_set(
+            sqlite_dialect_3_38_0,
+            '{"a": 1}',
+            "$.a",
+            10,
+            "$.b",
+            20
+        )
+        sql, _ = result.to_sql()
+        assert "JSON_SET(" in sql
+
+    def test_json_insert(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_insert()."""
+        result = json_insert(
+            sqlite_dialect_3_38_0,
+            Column(sqlite_dialect_3_38_0, "data"),
+            "$.b",
+            "new_value"
+        )
+        sql, params = result.to_sql()
+        assert "JSON_INSERT(" in sql
+        assert params == ("$.b", "new_value")
+
+    def test_json_replace(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_replace()."""
+        result = json_replace(
+            sqlite_dialect_3_38_0,
+            Column(sqlite_dialect_3_38_0, "data"),
+            "$.a",
+            "replaced"
+        )
+        sql, params = result.to_sql()
+        assert "JSON_REPLACE(" in sql
+        assert params == ("$.a", "replaced")
+
+    def test_json_patch(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_patch()."""
+        result = json_patch(
+            sqlite_dialect_3_38_0,
+            Column(sqlite_dialect_3_38_0, "target"),
+            Column(sqlite_dialect_3_38_0, "patch")
+        )
+        sql, _ = result.to_sql()
+        assert "JSON_PATCH(" in sql
+
+    def test_json_array_length(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_array_length()."""
+        result = json_array_length(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"))
+        sql, _ = result.to_sql()
+        assert "JSON_ARRAY_LENGTH(" in sql
+
+    def test_json_array_length_with_path(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_array_length() with path."""
+        result = json_array_length(
+            sqlite_dialect_3_38_0,
+            Column(sqlite_dialect_3_38_0, "data"),
+            "$.items"
+        )
+        sql, params = result.to_sql()
+        assert "JSON_ARRAY_LENGTH(" in sql
+        assert params == ("$.items",)
+
+    def test_json_object_pack(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_object_pack()."""
+        result = json_object_pack(
+            sqlite_dialect_3_38_0,
+            "key",
+            "value"
+        )
+        sql, params = result.to_sql()
+        assert "JSON_OBJECT(" in sql
+        assert params == ("key", "value")
+
+    def test_json_object_retrieve(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_object_retrieve()."""
+        result = json_object_retrieve(
+            sqlite_dialect_3_38_0,
+            Column(sqlite_dialect_3_38_0, "data"),
+            "$.name"
+        )
+        sql, params = result.to_sql()
+        assert "JSON_EXTRACT(" in sql
+        assert params == ("$.name",)
+
+    def test_json_object_length(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_object_length()."""
+        result = json_object_length(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"))
+        sql, _ = result.to_sql()
+        assert "JSON_OBJECT_LENGTH(" in sql
+
+    def test_json_object_keys(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_object_keys()."""
+        result = json_object_keys(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"))
+        sql, _ = result.to_sql()
+        assert "JSON_OBJECT_KEYS(" in sql
+
+    def test_json_object_keys_with_path(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_object_keys() with path."""
+        result = json_object_keys(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"), "$.nested")
+        sql, params = result.to_sql()
+        assert "JSON_OBJECT_KEYS(" in sql
+        assert params == ("$.nested",)
+
+    def test_json_object_length_with_path(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_object_length() with path."""
+        result = json_object_length(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"), "$.nested")
+        sql, params = result.to_sql()
+        assert "JSON_OBJECT_LENGTH(" in sql
+        assert params == ("$.nested",)
+
+    def test_json_array_unpack(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_array_unpack()."""
+        result = json_array_unpack(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"))
+        sql, _ = result.to_sql()
+        assert "JSON_ARRAY_LENGTH(" in sql
+
+    def test_json_array_unpack_with_path(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_array_unpack() with path."""
+        result = json_array_unpack(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"), "$.items")
+        sql, params = result.to_sql()
+        assert "JSON_ARRAY_LENGTH(" in sql
+        assert params == ("$.items",)
+
+    def test_json_tree(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_tree()."""
+        result = json_tree(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"))
+        sql, _ = result.to_sql()
+        assert "JSON_TREE(" in sql
+
+    def test_json_tree_with_path(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_tree() with path."""
+        result = json_tree(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"), "$.nested")
+        sql, params = result.to_sql()
+        assert "JSON_TREE(" in sql
+        assert params == ("$.nested",)
+
+    def test_json_each(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_each()."""
+        result = json_each(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"))
+        sql, _ = result.to_sql()
+        assert "JSON_EACH(" in sql
+
+    def test_json_each_with_path(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_each() with path."""
+        result = json_each(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "data"), "$.items")
+        sql, params = result.to_sql()
+        assert "JSON_EACH(" in sql
+        assert params == ("$.items",)
+
+    def test_json_set_with_expression_value(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_set() with expression as value."""
+        result = json_set(
+            sqlite_dialect_3_38_0,
+            Column(sqlite_dialect_3_38_0, "data"),
+            "$.a",
+            Column(sqlite_dialect_3_38_0, "other")
+        )
+        sql, _ = result.to_sql()
+        assert "JSON_SET(" in sql
+
+    def test_json_insert_with_multiple_pairs(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_insert() with multiple path-value pairs."""
+        result = json_insert(
+            sqlite_dialect_3_38_0,
+            Column(sqlite_dialect_3_38_0, "data"),
+            "$.a",
+            1,
+            "$.b",
+            2
+        )
+        sql, _ = result.to_sql()
+        assert "JSON_INSERT(" in sql
+
+    def test_json_replace_with_multiple_pairs(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_replace() with multiple path-value pairs."""
+        result = json_replace(
+            sqlite_dialect_3_38_0,
+            Column(sqlite_dialect_3_38_0, "data"),
+            "$.a",
+            "new_a",
+            "$.b",
+            "new_b"
+        )
+        sql, _ = result.to_sql()
+        assert "JSON_REPLACE(" in sql
+
+    def test_json_patch_with_literals(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json_patch() with literal values."""
+        result = json_patch(sqlite_dialect_3_38_0, '{"a": 1}', '{"a": 2}')
+        sql, params = result.to_sql()
+        assert "JSON_PATCH(" in sql
+        assert params == ('{"a": 1}', '{"a": 2}')
+
+    def test_json_with_numeric(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test json() with numeric value converted to JSON."""
+        result = json(sqlite_dialect_3_38_0, 42)
+        sql, params = result.to_sql()
+        assert "JSON(" in sql
+        assert params == (42,)

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_math_enhanced_functions.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_math_enhanced_functions.py
@@ -1,0 +1,248 @@
+# tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_math_enhanced_functions.py
+"""
+Tests for SQLite-specific enhanced math functions.
+These include additional mathematical functions beyond the basic math module.
+"""
+from rhosocial.activerecord.backend.expression import Column
+from rhosocial.activerecord.backend.impl.sqlite.dialect import SQLiteDialect
+from rhosocial.activerecord.backend.impl.sqlite.functions.math_enhanced import (
+    round_sql,
+    pow,
+    power,
+    sqrt,
+    mod,
+    ceil,
+    floor,
+    trunc,
+    max_sql,
+    min_sql,
+    avg,
+)
+
+
+class TestSQLiteMathEnhancedFunctions:
+    """Tests for SQLite enhanced math functions."""
+
+    def test_round_sql_default(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test round_sql() with default precision."""
+        result = round_sql(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "value"))
+        sql, _ = result.to_sql()
+        assert "ROUND(" in sql
+        assert '"value"' in sql
+
+    def test_round_sql_with_precision(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test round_sql() with precision."""
+        result = round_sql(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "price"), 2)
+        sql, _ = result.to_sql()
+        assert "ROUND(" in sql
+        # precision is stored as literal in expression, not as param
+
+    def test_round_sql_with_literal(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test round_sql() with literal value."""
+        result = round_sql(sqlite_dialect_3_8_0, 3.14159, 2)
+        sql, _ = result.to_sql()
+        assert "ROUND(" in sql
+
+    def test_pow(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test pow() function."""
+        result = pow(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "base"), 2)
+        sql, _ = result.to_sql()
+        assert "POW(" in sql
+
+    def test_pow_both_columns(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test pow() with both column references."""
+        result = pow(
+            sqlite_dialect_3_8_0,
+            Column(sqlite_dialect_3_8_0, "x"),
+            Column(sqlite_dialect_3_8_0, "y")
+        )
+        sql, _ = result.to_sql()
+        assert "POW(" in sql
+
+    def test_power(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test power() function (alias for POW)."""
+        result = power(sqlite_dialect_3_8_0, 2, 3)
+        sql, _ = result.to_sql()
+        assert "POWER(" in sql
+
+    def test_sqrt(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test sqrt() function."""
+        result = sqrt(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "value"))
+        sql, _ = result.to_sql()
+        assert "SQRT(" in sql
+        assert '"value"' in sql
+
+    def test_sqrt_with_literal(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test sqrt() with literal value."""
+        result = sqrt(sqlite_dialect_3_8_0, 16)
+        sql, _ = result.to_sql()
+        assert "SQRT(" in sql
+
+    def test_mod(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test mod() function."""
+        result = mod(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "total"), 10)
+        sql, _ = result.to_sql()
+        assert "MOD(" in sql
+
+    def test_mod_both_columns(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test mod() with both column references."""
+        result = mod(
+            sqlite_dialect_3_8_0,
+            Column(sqlite_dialect_3_8_0, "dividend"),
+            Column(sqlite_dialect_3_8_0, "divisor")
+        )
+        sql, _ = result.to_sql()
+        assert "MOD(" in sql
+
+    def test_ceil(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test ceil() function (SQLite 3.44.0+)."""
+        result = ceil(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "value"))
+        sql, _ = result.to_sql()
+        assert "CEIL(" in sql
+        assert '"value"' in sql
+
+    def test_ceil_with_literal(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test ceil() with literal value."""
+        result = ceil(sqlite_dialect_3_38_0, 3.14)
+        sql, _ = result.to_sql()
+        assert "CEIL(" in sql
+
+    def test_floor(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test floor() function (SQLite 3.44.0+)."""
+        result = floor(sqlite_dialect_3_38_0, Column(sqlite_dialect_3_38_0, "value"))
+        sql, _ = result.to_sql()
+        assert "FLOOR(" in sql
+        assert '"value"' in sql
+
+    def test_floor_with_literal(self, sqlite_dialect_3_38_0: SQLiteDialect):
+        """Test floor() with literal value."""
+        result = floor(sqlite_dialect_3_38_0, 3.14)
+        sql, _ = result.to_sql()
+        assert "FLOOR(" in sql
+
+    def test_trunc(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test trunc() function."""
+        result = trunc(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "value"))
+        sql, _ = result.to_sql()
+        assert "TRUNC(" in sql
+        assert '"value"' in sql
+
+    def test_trunc_with_literal(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test trunc() with literal value."""
+        result = trunc(sqlite_dialect_3_8_0, 3.14)
+        sql, _ = result.to_sql()
+        assert "TRUNC(" in sql
+
+    def test_max_sql_two_args(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test max_sql() with two arguments."""
+        result = max_sql(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "a"), Column(sqlite_dialect_3_8_0, "b"))
+        sql, _ = result.to_sql()
+        assert "MAX(" in sql
+
+    def test_max_sql_multiple_args(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test max_sql() with multiple arguments."""
+        result = max_sql(
+            sqlite_dialect_3_8_0,
+            Column(sqlite_dialect_3_8_0, "a"),
+            Column(sqlite_dialect_3_8_0, "b"),
+            Column(sqlite_dialect_3_8_0, "c")
+        )
+        sql, _ = result.to_sql()
+        assert "MAX(" in sql
+
+    def test_max_sql_with_literals(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test max_sql() with literal values."""
+        result = max_sql(sqlite_dialect_3_8_0, 1, 2, 3)
+        sql, _ = result.to_sql()
+        assert "MAX(" in sql
+
+    def test_min_sql_two_args(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test min_sql() with two arguments."""
+        result = min_sql(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "a"), Column(sqlite_dialect_3_8_0, "b"))
+        sql, _ = result.to_sql()
+        assert "MIN(" in sql
+
+    def test_min_sql_multiple_args(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test min_sql() with multiple arguments."""
+        result = min_sql(
+            sqlite_dialect_3_8_0,
+            Column(sqlite_dialect_3_8_0, "a"),
+            Column(sqlite_dialect_3_8_0, "b"),
+            Column(sqlite_dialect_3_8_0, "c")
+        )
+        sql, _ = result.to_sql()
+        assert "MIN(" in sql
+
+    def test_min_sql_with_literals(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test min_sql() with literal values."""
+        result = min_sql(sqlite_dialect_3_8_0, 1, 2, 3)
+        sql, _ = result.to_sql()
+        assert "MIN(" in sql
+
+    def test_avg(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test avg() aggregate function."""
+        result = avg(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "price"))
+        sql, _ = result.to_sql()
+        assert "AVG(" in sql
+        assert '"price"' in sql
+
+    def test_avg_with_literal(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test avg() with literal value."""
+        result = avg(sqlite_dialect_3_8_0, 100)
+        sql, _ = result.to_sql()
+        assert "AVG(" in sql
+
+    def test_round_sql_with_string_integer(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test round_sql() with string integer value."""
+        result = round_sql(sqlite_dialect_3_8_0, "123", 2)
+        sql, _ = result.to_sql()
+        assert "ROUND(" in sql
+
+    def test_round_sql_with_string_float(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test round_sql() with string float value."""
+        result = round_sql(sqlite_dialect_3_8_0, "3.14159", 2)
+        sql, _ = result.to_sql()
+        assert "ROUND(" in sql
+
+    def test_round_sql_with_string_column_name(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test round_sql() with non-numeric string treated as column."""
+        result = round_sql(sqlite_dialect_3_8_0, "column_name", 2)
+        sql, _ = result.to_sql()
+        assert "ROUND(" in sql
+        assert '"column_name"' in sql
+
+    def test_pow_with_string_integer(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test pow() with string integer exponent."""
+        result = pow(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "base"), "2")
+        sql, _ = result.to_sql()
+        assert "POW(" in sql
+
+    def test_sqrt_with_string_integer(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test sqrt() with string integer value."""
+        result = sqrt(sqlite_dialect_3_8_0, "16")
+        sql, _ = result.to_sql()
+        assert "SQRT(" in sql
+
+    def test_mod_with_string_divisor(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test mod() with string divisor."""
+        result = mod(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "total"), "10")
+        sql, _ = result.to_sql()
+        assert "MOD(" in sql
+
+    def test_max_sql_with_string_literals(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test max_sql() with string numeric values."""
+        result = max_sql(sqlite_dialect_3_8_0, "1", "2", "3")
+        sql, _ = result.to_sql()
+        assert "MAX(" in sql
+
+    def test_min_sql_with_string_literals(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test min_sql() with string numeric values."""
+        result = min_sql(sqlite_dialect_3_8_0, "1", "2", "3")
+        sql, _ = result.to_sql()
+        assert "MIN(" in sql
+
+    def test_avg_with_string_literal(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test avg() with string numeric value."""
+        result = avg(sqlite_dialect_3_8_0, "100")
+        sql, _ = result.to_sql()
+        assert "AVG(" in sql

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_math_enhanced_functions.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_math_enhanced_functions.py
@@ -6,7 +6,7 @@ These include additional mathematical functions beyond the basic math module.
 from rhosocial.activerecord.backend.expression import Column
 from rhosocial.activerecord.backend.impl.sqlite.dialect import SQLiteDialect
 from rhosocial.activerecord.backend.impl.sqlite.functions.math_enhanced import (
-    round_sql,
+    round_,
     pow,
     power,
     sqrt,
@@ -14,8 +14,8 @@ from rhosocial.activerecord.backend.impl.sqlite.functions.math_enhanced import (
     ceil,
     floor,
     trunc,
-    max_sql,
-    min_sql,
+    max_,
+    min_,
     avg,
 )
 
@@ -23,23 +23,23 @@ from rhosocial.activerecord.backend.impl.sqlite.functions.math_enhanced import (
 class TestSQLiteMathEnhancedFunctions:
     """Tests for SQLite enhanced math functions."""
 
-    def test_round_sql_default(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test round_sql() with default precision."""
-        result = round_sql(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "value"))
+    def test_round__default(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test round_() with default precision."""
+        result = round_(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "value"))
         sql, _ = result.to_sql()
         assert "ROUND(" in sql
         assert '"value"' in sql
 
-    def test_round_sql_with_precision(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test round_sql() with precision."""
-        result = round_sql(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "price"), 2)
+    def test_round__with_precision(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test round_() with precision."""
+        result = round_(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "price"), 2)
         sql, _ = result.to_sql()
         assert "ROUND(" in sql
         # precision is stored as literal in expression, not as param
 
-    def test_round_sql_with_literal(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test round_sql() with literal value."""
-        result = round_sql(sqlite_dialect_3_8_0, 3.14159, 2)
+    def test_round__with_literal(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test round_() with literal value."""
+        result = round_(sqlite_dialect_3_8_0, 3.14159, 2)
         sql, _ = result.to_sql()
         assert "ROUND(" in sql
 
@@ -133,15 +133,15 @@ class TestSQLiteMathEnhancedFunctions:
         sql, _ = result.to_sql()
         assert "TRUNC(" in sql
 
-    def test_max_sql_two_args(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test max_sql() with two arguments."""
-        result = max_sql(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "a"), Column(sqlite_dialect_3_8_0, "b"))
+    def test_max__two_args(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test max_() with two arguments."""
+        result = max_(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "a"), Column(sqlite_dialect_3_8_0, "b"))
         sql, _ = result.to_sql()
         assert "MAX(" in sql
 
-    def test_max_sql_multiple_args(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test max_sql() with multiple arguments."""
-        result = max_sql(
+    def test_max__multiple_args(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test max_() with multiple arguments."""
+        result = max_(
             sqlite_dialect_3_8_0,
             Column(sqlite_dialect_3_8_0, "a"),
             Column(sqlite_dialect_3_8_0, "b"),
@@ -150,21 +150,21 @@ class TestSQLiteMathEnhancedFunctions:
         sql, _ = result.to_sql()
         assert "MAX(" in sql
 
-    def test_max_sql_with_literals(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test max_sql() with literal values."""
-        result = max_sql(sqlite_dialect_3_8_0, 1, 2, 3)
+    def test_max__with_literals(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test max_() with literal values."""
+        result = max_(sqlite_dialect_3_8_0, 1, 2, 3)
         sql, _ = result.to_sql()
         assert "MAX(" in sql
 
-    def test_min_sql_two_args(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test min_sql() with two arguments."""
-        result = min_sql(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "a"), Column(sqlite_dialect_3_8_0, "b"))
+    def test_min__two_args(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test min_() with two arguments."""
+        result = min_(sqlite_dialect_3_8_0, Column(sqlite_dialect_3_8_0, "a"), Column(sqlite_dialect_3_8_0, "b"))
         sql, _ = result.to_sql()
         assert "MIN(" in sql
 
-    def test_min_sql_multiple_args(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test min_sql() with multiple arguments."""
-        result = min_sql(
+    def test_min__multiple_args(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test min_() with multiple arguments."""
+        result = min_(
             sqlite_dialect_3_8_0,
             Column(sqlite_dialect_3_8_0, "a"),
             Column(sqlite_dialect_3_8_0, "b"),
@@ -173,9 +173,9 @@ class TestSQLiteMathEnhancedFunctions:
         sql, _ = result.to_sql()
         assert "MIN(" in sql
 
-    def test_min_sql_with_literals(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test min_sql() with literal values."""
-        result = min_sql(sqlite_dialect_3_8_0, 1, 2, 3)
+    def test_min__with_literals(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test min_() with literal values."""
+        result = min_(sqlite_dialect_3_8_0, 1, 2, 3)
         sql, _ = result.to_sql()
         assert "MIN(" in sql
 
@@ -192,21 +192,21 @@ class TestSQLiteMathEnhancedFunctions:
         sql, _ = result.to_sql()
         assert "AVG(" in sql
 
-    def test_round_sql_with_string_integer(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test round_sql() with string integer value."""
-        result = round_sql(sqlite_dialect_3_8_0, "123", 2)
+    def test_round__with_string_integer(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test round_() with string integer value."""
+        result = round_(sqlite_dialect_3_8_0, "123", 2)
         sql, _ = result.to_sql()
         assert "ROUND(" in sql
 
-    def test_round_sql_with_string_float(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test round_sql() with string float value."""
-        result = round_sql(sqlite_dialect_3_8_0, "3.14159", 2)
+    def test_round__with_string_float(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test round_() with string float value."""
+        result = round_(sqlite_dialect_3_8_0, "3.14159", 2)
         sql, _ = result.to_sql()
         assert "ROUND(" in sql
 
-    def test_round_sql_with_string_column_name(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test round_sql() with non-numeric string treated as column."""
-        result = round_sql(sqlite_dialect_3_8_0, "column_name", 2)
+    def test_round__with_string_column_name(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test round_() with non-numeric string treated as column."""
+        result = round_(sqlite_dialect_3_8_0, "column_name", 2)
         sql, _ = result.to_sql()
         assert "ROUND(" in sql
         assert '"column_name"' in sql
@@ -229,15 +229,15 @@ class TestSQLiteMathEnhancedFunctions:
         sql, _ = result.to_sql()
         assert "MOD(" in sql
 
-    def test_max_sql_with_string_literals(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test max_sql() with string numeric values."""
-        result = max_sql(sqlite_dialect_3_8_0, "1", "2", "3")
+    def test_max__with_string_literals(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test max_() with string numeric values."""
+        result = max_(sqlite_dialect_3_8_0, "1", "2", "3")
         sql, _ = result.to_sql()
         assert "MAX(" in sql
 
-    def test_min_sql_with_string_literals(self, sqlite_dialect_3_8_0: SQLiteDialect):
-        """Test min_sql() with string numeric values."""
-        result = min_sql(sqlite_dialect_3_8_0, "1", "2", "3")
+    def test_min__with_string_literals(self, sqlite_dialect_3_8_0: SQLiteDialect):
+        """Test min_() with string numeric values."""
+        result = min_(sqlite_dialect_3_8_0, "1", "2", "3")
         sql, _ = result.to_sql()
         assert "MIN(" in sql
 


### PR DESCRIPTION
## Description

Adds SQLite JSON functions and enhanced math function factories to the `python-activerecord` core package.

### Summary

This PR introduces:

1. **JSON Function Factories** - Support for SQLite JSON functions including `json`, `json_array`, `json_extract`, `json_insert`, `json_replace`, `json_set`, `json_remove`, `json_object`, `json_type`, `json_valid`, `json_each`, and `json_tree`

2. **Enhanced Math Function Factories** - Improved math functions with proper SQL naming conflict resolution and comprehensive function coverage

### Commits

- `0c42b8d` feat(sqlite): add JSON and enhanced math function factories
- `af6411a` test(sqlite): add integration and unit tests for JSON and math functions
- `8fe3e02` refactor(sqlite): rename math functions to avoid SQL naming conflicts

## Type of change

- [x] `feat`: A new feature
- [x] `test`: Adding missing tests or correcting existing tests
- [ ] `docs`: Documentation only changes
- [ ] `perf`: A code change that improves performance
- [ ] `chore`: Changes to the build process or auxiliary tools
- [ ] `ci`: Changes to our CI configuration files and scripts
- [ ] `build`: Changes that affect the build system or external dependencies
- [ ] `revert`: Reverts a previous commit

## Breaking Change

- [ ] Yes, for end-users (backward-incompatible API changes)
- [ ] Yes, for backend developers (internal architectural changes that may affect custom implementations)
- [x] No breaking changes

**Impact on End-Users:**
No backward-incompatible changes are expected for typical end-user applications.

**Impact on Backend Developers (Custom Implementations):**
No backward-incompatible changes are expected for backend developers using custom implementations.

## Related Repositories/Packages

<!-- If this change affects other repositories in the rhosocial-activerecord ecosystem, please list them. -->

N/A - This change is contained within the core `python-activerecord` package.

## Testing

- [x] I have added new tests to cover my changes.
- [ ] I have updated existing tests to reflect my changes.
- [x] All existing tests pass.
- [x] This change has been tested on SQLite 3.8.3+

**Test Plan:**
Tests added in `tests/rhosocial/activerecord_test/` for JSON and math functions.

## Checklist

- [x] My code follows the project's code style guidelines.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (Docstrings, `README.md`, etc.).
- [x] My changes generate no new warnings.
- [ ] I have added a Changelog fragment (`changelog.d/<issue_number>.<type>.md`).
- [x] I have verified that my changes do not introduce SQL injection vulnerabilities.
- [ ] I have checked for potential performance regressions.

## Additional Notes

Target branch: `release/v1.0.0.dev23`
