### PR TITLE
feat(protocol): split returning support into DML-specific flags (insert/update/delete)

### DIFF
--- a/changelog.d/88.added.md
+++ b/changelog.d/88.added.md
@@ -1,0 +1,1 @@
+Split `ReturningSupport.supports_returning_clause()` into DML-specific flags for INSERT, UPDATE, and DELETE.

--- a/src/rhosocial/activerecord/backend/dialect/base.py
+++ b/src/rhosocial/activerecord/backend/dialect/base.py
@@ -972,6 +972,11 @@ class SQLDialectBase:
             all_params.extend(conflict_params)
 
         if expr.returning:
+            if not self.supports_returning_insert():
+                raise UnsupportedFeatureError(
+                    self.name, "RETURNING clause in INSERT",
+                    "This dialect does not support RETURNING in INSERT statements."
+                )
             returning_sql, returning_params = self.format_returning_clause(expr.returning)
             sql += f" {returning_sql}"
             all_params.extend(returning_params)
@@ -1040,6 +1045,11 @@ class SQLDialectBase:
 
         # RETURNING clause
         if expr.returning:
+            if not self.supports_returning_update():
+                raise UnsupportedFeatureError(
+                    self.name, "RETURNING clause in UPDATE",
+                    "This dialect does not support RETURNING in UPDATE statements."
+                )
             returning_sql, returning_params = self.format_returning_clause(
                 expr.returning
             )  # This returns "RETURNING col1, ..."
@@ -1121,6 +1131,11 @@ class SQLDialectBase:
 
         # RETURNING clause
         if expr.returning:
+            if not self.supports_returning_delete():
+                raise UnsupportedFeatureError(
+                    self.name, "RETURNING clause in DELETE",
+                    "This dialect does not support RETURNING in DELETE statements."
+                )
             returning_sql, returning_params = self.format_returning_clause(expr.returning)
             current_sql += f" {returning_sql}"
             all_params.extend(returning_params)

--- a/src/rhosocial/activerecord/backend/dialect/mixins.py
+++ b/src/rhosocial/activerecord/backend/dialect/mixins.py
@@ -337,9 +337,27 @@ class AdvancedGroupingMixin:
 class ReturningMixin:
     """Mixin for RETURNING clause support."""
 
-    def supports_returning_clause(self) -> bool:
-        """Whether RETURNING clause is supported."""
+    def supports_returning_insert(self) -> bool:
+        """Whether RETURNING clause is supported for INSERT statements."""
         return False
+
+    def supports_returning_update(self) -> bool:
+        """Whether RETURNING clause is supported for UPDATE statements."""
+        return False
+
+    def supports_returning_delete(self) -> bool:
+        """Whether RETURNING clause is supported for DELETE statements."""
+        return False
+
+    def supports_returning_clause(self) -> bool:
+        """Whether RETURNING clause is generally supported.
+        Default is AND of all DML-specific returning support flags.
+        """
+        return (
+            self.supports_returning_insert()
+            and self.supports_returning_update()
+            and self.supports_returning_delete()
+        )
 
     def format_returning_clause(self, clause: "ReturningClause") -> Tuple[str, Tuple]:
         """
@@ -351,9 +369,6 @@ class ReturningMixin:
         Returns:
             Tuple of (SQL string, parameters tuple)
         """
-        if not self.supports_returning_clause():
-            raise UnsupportedFeatureError(self.name, "RETURNING clause")
-
         all_params = []
         expr_parts = []
         for expr in clause.expressions:

--- a/src/rhosocial/activerecord/backend/dialect/protocols.py
+++ b/src/rhosocial/activerecord/backend/dialect/protocols.py
@@ -264,7 +264,23 @@ class ReturningSupport(Protocol):
     """Protocol for RETURNING clause support."""
 
     def supports_returning_clause(self) -> bool:
-        """Whether RETURNING clause is supported."""
+        """Whether RETURNING clause is generally supported.
+        This is the AND of all DML-specific returning support flags
+        (supports_returning_insert, supports_returning_update,
+        supports_returning_delete).
+        """
+        ...  # pragma: no cover
+
+    def supports_returning_insert(self) -> bool:
+        """Whether RETURNING clause is supported for INSERT statements."""
+        ...  # pragma: no cover
+
+    def supports_returning_update(self) -> bool:
+        """Whether RETURNING clause is supported for UPDATE statements."""
+        ...  # pragma: no cover
+
+    def supports_returning_delete(self) -> bool:
+        """Whether RETURNING clause is supported for DELETE statements."""
         ...  # pragma: no cover
 
     def format_returning_clause(self, clause: "ReturningClause") -> Tuple[str, Tuple]:

--- a/src/rhosocial/activerecord/backend/impl/dummy/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/dummy/dialect.py
@@ -221,7 +221,13 @@ class DummyDialect(
     def supports_grouping_sets(self) -> bool:
         return True
 
-    def supports_returning_clause(self) -> bool:
+    def supports_returning_insert(self) -> bool:
+        return True
+
+    def supports_returning_update(self) -> bool:
+        return True
+
+    def supports_returning_delete(self) -> bool:
         return True
 
     def supports_upsert(self) -> bool:

--- a/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
@@ -246,8 +246,16 @@ class SQLiteDialect(
         """MATERIALIZED hint is supported since SQLite 3.35.0."""
         return self.version >= (3, 35, 0)
 
-    def supports_returning_clause(self) -> bool:
-        """RETURNING clause is supported since SQLite 3.35.0."""
+    def supports_returning_insert(self) -> bool:
+        """RETURNING clause is supported for INSERT since SQLite 3.35.0."""
+        return self.version >= (3, 35, 0)
+
+    def supports_returning_update(self) -> bool:
+        """RETURNING clause is supported for UPDATE since SQLite 3.35.0."""
+        return self.version >= (3, 35, 0)
+
+    def supports_returning_delete(self) -> bool:
+        """RETURNING clause is supported for DELETE since SQLite 3.35.0."""
         return self.version >= (3, 35, 0)
 
     def supports_window_functions(self) -> bool:
@@ -503,6 +511,11 @@ class SQLiteDialect(
 
         # RETURNING clause
         if expr.returning:
+            if not self.supports_returning_insert():
+                raise UnsupportedFeatureError(
+                    self.name, "RETURNING clause in INSERT",
+                    "This SQLite version does not support RETURNING in INSERT statements."
+                )
             returning_sql, returning_params = self.format_returning_clause(expr.returning)
             sql += f" {returning_sql}"
             all_params.extend(returning_params)
@@ -818,12 +831,6 @@ class SQLiteDialect(
 
     def format_returning_clause(self, clause: "ReturningClause") -> Tuple[str, tuple]:
         """Format RETURNING clause."""
-        # Check if the dialect supports returning clause
-        if not self.supports_returning_clause():
-            raise UnsupportedFeatureError(
-                self.name, "RETURNING clause", "Use a separate SELECT statement to retrieve the affected data."
-            )
-
         all_params = []
         expr_parts = []
         for expr in clause.expressions:

--- a/src/rhosocial/activerecord/base/base.py
+++ b/src/rhosocial/activerecord/base/base.py
@@ -123,7 +123,7 @@ class BaseActiveRecord(LoggingMixin, IActiveRecord):
         self.log(logging.DEBUG, f"Column mapping for result processing: {column_mapping}")
         column_adapters = self.get_column_adapters()
         self.log(logging.DEBUG, f"Column adapters map: {column_adapters}")
-        supports_returning = self.backend().dialect.supports_returning_clause()
+        supports_returning = self.backend().dialect.supports_returning_insert()
         returning_columns = None
         if supports_returning:
             returning_columns = [self.primary_key()]
@@ -284,7 +284,7 @@ class BaseActiveRecord(LoggingMixin, IActiveRecord):
         self.log(
             logging.DEBUG, f"Final WHERE clause conditions: {len(update_conditions)} additional condition(s) applied"
         )
-        supports_returning = backend.dialect.supports_returning_clause()
+        supports_returning = backend.dialect.supports_returning_update()
         returning_columns = None
         if supports_returning:
             returning_columns = [self.primary_key()]
@@ -485,7 +485,7 @@ class BaseActiveRecord(LoggingMixin, IActiveRecord):
             result = backend.update(update_opts)
         else:
             self.log(logging.INFO, f"Deleting {self.__class__.__name__}#{pk_value}")
-            supports_returning = backend.dialect.supports_returning_clause()
+            supports_returning = backend.dialect.supports_returning_delete()
             returning_columns = None
             if supports_returning:
                 returning_columns = [self.primary_key()]
@@ -650,7 +650,7 @@ class AsyncBaseActiveRecord(LoggingMixin, IAsyncActiveRecord):
         self.log(logging.DEBUG, f"Column mapping for result processing: {column_mapping}")
         column_adapters = self.get_column_adapters()
         self.log(logging.DEBUG, f"Column adapters map: {column_adapters}")
-        supports_returning = self.backend().dialect.supports_returning_clause()
+        supports_returning = self.backend().dialect.supports_returning_insert()
         returning_columns = None
         if supports_returning:
             returning_columns = [self.primary_key()]
@@ -811,7 +811,7 @@ class AsyncBaseActiveRecord(LoggingMixin, IAsyncActiveRecord):
         self.log(
             logging.DEBUG, f"Final WHERE clause conditions: {len(update_conditions)} additional condition(s) applied"
         )
-        supports_returning = backend.dialect.supports_returning_clause()
+        supports_returning = backend.dialect.supports_returning_update()
         returning_columns = None
         if supports_returning:
             returning_columns = [self.primary_key()]
@@ -1012,7 +1012,7 @@ class AsyncBaseActiveRecord(LoggingMixin, IAsyncActiveRecord):
             result = await backend.update(update_opts)
         else:
             self.log(logging.INFO, f"Deleting {self.__class__.__name__}#{pk_value}")
-            supports_returning = backend.dialect.supports_returning_clause()
+            supports_returning = backend.dialect.supports_returning_delete()
             returning_columns = None
             if supports_returning:
                 returning_columns = [self.primary_key()]

--- a/tests/rhosocial/activerecord_test/feature/backend/dialect/test_returning_protocol.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/dialect/test_returning_protocol.py
@@ -64,3 +64,55 @@ def test_supports_returning_clause_is_and_of_dml():
     assert dialect.supports_returning_insert()
     assert not dialect.supports_returning_update()
     assert not dialect.supports_returning_delete()
+
+
+class TestFormatDmlReturningErrors:
+    """Test that UnsupportedFeatureError is raised for DML RETURNING when unsupported."""
+
+    def test_format_insert_returning_unsupported(self):
+        """Test INSERT RETURNING raises error when insert returning is unsupported."""
+        from unittest.mock import MagicMock
+
+        dialect = NoReturningDialect()
+        dialect.strict_validation = False
+        mock_expr = MagicMock()
+        mock_expr.into.to_sql.return_value = ("test_table", ())
+        mock_expr.columns = []
+        mock_expr.source = None
+        mock_expr.on_conflict = None
+        mock_expr.returning = MagicMock()
+
+        with pytest.raises(UnsupportedFeatureError, match="RETURNING clause in INSERT"):
+            dialect.format_insert_statement(mock_expr)
+
+    def test_format_update_returning_unsupported(self):
+        """Test UPDATE RETURNING raises error when update returning is unsupported."""
+        from unittest.mock import MagicMock
+
+        dialect = NoReturningDialect()
+        mock_expr = MagicMock()
+        mock_expr.table.to_sql.return_value = ("test_table", ())
+        mock_expr.assignments = {}
+        mock_expr.from_ = None
+        mock_expr.where = None
+        mock_expr.returning = MagicMock()
+
+        with pytest.raises(UnsupportedFeatureError, match="RETURNING clause in UPDATE"):
+            dialect.format_update_statement(mock_expr)
+
+    def test_format_delete_returning_unsupported(self):
+        """Test DELETE RETURNING raises error when delete returning is unsupported."""
+        from unittest.mock import MagicMock
+
+        dialect = NoReturningDialect()
+        dialect.strict_validation = False
+        mock_table = MagicMock()
+        mock_table.to_sql.return_value = ("test_table", ())
+        mock_expr = MagicMock()
+        mock_expr.tables = [mock_table]
+        mock_expr.using = None
+        mock_expr.where = None
+        mock_expr.returning = MagicMock()
+
+        with pytest.raises(UnsupportedFeatureError, match="RETURNING clause in DELETE"):
+            dialect.format_delete_statement(mock_expr)

--- a/tests/rhosocial/activerecord_test/feature/backend/dialect/test_returning_protocol.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/dialect/test_returning_protocol.py
@@ -1,9 +1,8 @@
-# tests/rhosocial/activerecord_test/feature/backend/dialect/test_returning_protocol.py
 """
 Test for ReturningSupport protocol implementation.
 
 This test creates a dialect that does not support RETURNING clauses and verifies that
-the corresponding formatting methods raise appropriate errors.
+the corresponding capability flags work correctly.
 """
 import pytest
 
@@ -15,7 +14,23 @@ from rhosocial.activerecord.backend.expression import Column
 
 class NoReturningDialect(SQLDialectBase, ReturningMixin, ReturningSupport):
     """Dialect that does not support RETURNING clauses."""
-    
+
+    def supports_returning_clause(self) -> bool:
+        return False
+
+
+class OnlyInsertReturningDialect(SQLDialectBase, ReturningMixin, ReturningSupport):
+    """Dialect that only supports RETURNING for INSERT."""
+
+    def supports_returning_insert(self) -> bool:
+        return True
+
+    def supports_returning_update(self) -> bool:
+        return False
+
+    def supports_returning_delete(self) -> bool:
+        return False
+
     def supports_returning_clause(self) -> bool:
         return False
 
@@ -23,24 +38,29 @@ class NoReturningDialect(SQLDialectBase, ReturningMixin, ReturningSupport):
 def test_no_returning_dialect_does_not_support_features():
     """Test that no-returning dialect properly indicates lack of RETURNING clause features."""
     dialect = NoReturningDialect()
-    
-    # Verify protocol implementation
+
     assert isinstance(dialect, ReturningSupport)
     assert not dialect.supports_returning_clause()
+    assert not dialect.supports_returning_insert()
+    assert not dialect.supports_returning_update()
+    assert not dialect.supports_returning_delete()
 
 
-def test_format_returning_clause_raises_error():
-    """Test that format_returning_clause method raises error in no-returning dialect."""
-    dialect = NoReturningDialect()
-    
-    # Create a mock ReturningClause
-    class MockReturningClause:
-        def __init__(self):
-            self.expressions = [Column(dialect, "id"), Column(dialect, "name")]
-            self.alias = None
-    
-    mock_clause = MockReturningClause()
-    
-    # This should raise an error
-    with pytest.raises(UnsupportedFeatureError):
-        dialect.format_returning_clause(mock_clause)
+def test_dml_specific_returning_support():
+    """Test that DML-specific returning support flags work correctly."""
+    dialect = OnlyInsertReturningDialect()
+
+    assert isinstance(dialect, ReturningSupport)
+    assert dialect.supports_returning_insert()
+    assert not dialect.supports_returning_update()
+    assert not dialect.supports_returning_delete()
+
+
+def test_supports_returning_clause_is_and_of_dml():
+    """Test that supports_returning_clause behavior matches the AND of DML-specific flags."""
+    dialect = OnlyInsertReturningDialect()
+
+    assert not dialect.supports_returning_clause()
+    assert dialect.supports_returning_insert()
+    assert not dialect.supports_returning_update()
+    assert not dialect.supports_returning_delete()

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_dialect_comprehensive.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_dialect_comprehensive.py
@@ -131,22 +131,27 @@ class TestSQLiteDialectComprehensive:
         expected_keyword = join_type.upper().split()[0]
         assert expected_keyword in str(exc_info.value)
 
-    def test_format_returning_clause_version_check_comprehensive(self):
-        """Comprehensive test for RETURNING clause version check"""
-        # Below 3.35.0 version should raise exception
+    def test_dml_returning_clause_version_check_comprehensive(self):
+        """Comprehensive test for DML RETURNING clause version check"""
+        from unittest.mock import MagicMock
+
+        # Below 3.35.0 version should raise exception for INSERT
         dialect = SQLiteDialect((3, 34, 0))
-        mock_clause = Mock()
-        mock_clause.expressions = []
-        mock_clause.alias = None
+        assert not dialect.supports_returning_insert()
+        assert not dialect.supports_returning_update()
+        assert not dialect.supports_returning_delete()
 
-        with pytest.raises(UnsupportedFeatureError):
-            dialect.format_returning_clause(mock_clause)
-
-        # 3.35.0 and above should work normally
+        # 3.35.0 and above should support all DML RETURNING
         dialect = SQLiteDialect((3, 35, 0))
-        mock_expr = Mock()
+        assert dialect.supports_returning_insert()
+        assert dialect.supports_returning_update()
+        assert dialect.supports_returning_delete()
+        assert dialect.supports_returning_clause()
+
+        # format_returning_clause should work for all versions (pure formatting)
+        mock_expr = MagicMock()
         mock_expr.to_sql.return_value = ("id", ())
-        mock_clause = Mock()
+        mock_clause = MagicMock()
         mock_clause.expressions = [mock_expr]
         mock_clause.alias = None
 

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_dialect_formatting.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_dialect_formatting.py
@@ -229,17 +229,23 @@ class TestSQLiteDialectFormatting:
         assert expected_error_part in str(exc_info.value)
 
     def test_format_returning_clause_unsupported_error(self):
-        """Test RETURNING clause formatting error (when unsupported)"""
+        """Test DML RETURNING clause version check (when unsupported)"""
         dialect = SQLiteDialect((3, 34, 0))  # Below version 3.35.0
+
+        assert not dialect.supports_returning_insert()
+        assert not dialect.supports_returning_update()
+        assert not dialect.supports_returning_delete()
+        assert not dialect.supports_returning_clause()
+
+        # format_returning_clause is pure formatting, no support check
+        mock_expr = Mock()
+        mock_expr.to_sql.return_value = ("id", ())
         mock_clause = Mock()
-        mock_clause.expressions = []
+        mock_clause.expressions = [mock_expr]
         mock_clause.alias = None
 
-        with pytest.raises(UnsupportedFeatureError) as exc_info:
-            dialect.format_returning_clause(mock_clause)
-
-        assert "RETURNING clause" in str(exc_info.value)
-        assert "Use a separate SELECT statement" in str(exc_info.value)
+        sql, params = dialect.format_returning_clause(mock_clause)
+        assert sql == "RETURNING id"
 
     def test_format_returning_clause_supported(self):
         """Test RETURNING clause formatting (when supported)"""


### PR DESCRIPTION
## Description

Split `ReturningSupport.supports_returning_clause()` into three DML-specific flags (`supports_returning_insert()`, `supports_returning_update()`, `supports_returning_delete()`), while keeping `supports_returning_clause()` as a composite AND of all three.

- `protocols.py`: Added three DML-specific methods to `ReturningSupport` protocol
- `mixins.py`: `ReturningMixin` implements DML methods and AND logic; removed support check from `format_returning_clause()`
- `base.py` (dialect): DML statement formatters now check their respective returning support
- SQLite dialect: DML methods check `version >= (3, 35, 0)`; `format_insert_statement` guards RETURNING clause
- Dummy dialect: All DML methods return `True`
- Model layer (`base/base.py`): 6 call sites updated to use DML-specific methods

## Type of change

- [x] `feat`: A new feature

## Breaking Change

- [x] No breaking changes

## Related Repositories/Packages

None.

## Testing

- [x] I have added new tests to cover my changes.
- [x] I have updated existing tests to reflect my changes.
- [x] All existing tests pass.

**Test Plan:**
```
pytest tests/ -v  → 5265 passed, 6 skipped
```

## Checklist

- [x] My code follows the project's code style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have added a Changelog fragment (`changelog.d/88.added.md`).
- [x] I have verified that my changes do not introduce SQL injection vulnerabilities.
- [x] I have checked for potential performance regressions.

## Additional Notes

This change enables backends to support RETURNING for different DML operations independently (e.g., INSERT only without UPDATE/DELETE support).