### PR TITLE
feat(backend): dialect version guarding without defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         pip install -r requirements-dev.txt
         pip install codecov build
 
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev13
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev14
 
     - name: Run tests with coverage
       run: |
@@ -83,7 +83,7 @@ jobs:
           pip install -r requirements-dev.txt
         fi
 
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev13
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev14
 
     - name: Run tests
       run: |
@@ -118,7 +118,7 @@ jobs:
           pip install -r requirements-dev.txt
         fi
 
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev13
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev14
 
     - name: Run tests
       run: |

--- a/changelog.d/89.changed.md
+++ b/changelog.d/89.changed.md
@@ -1,0 +1,1 @@
+Changed dialect version handling to default to None instead of fixed versions, introducing DialectNotAdaptedException to prevent silent SQL errors when dialect versions don't match actual server capabilities.

--- a/src/rhosocial/activerecord/backend/dialect/__init__.py
+++ b/src/rhosocial/activerecord/backend/dialect/__init__.py
@@ -34,7 +34,11 @@ except UnsupportedFeatureError as e:
 """
 
 from .base import SQLDialectBase
-from .exceptions import UnsupportedFeatureError, ProtocolNotImplementedError
+from .exceptions import (
+    UnsupportedFeatureError,
+    ProtocolNotImplementedError,
+    DialectNotAdaptedException,
+)
 from .protocols import (
     WindowFunctionSupport,
     CTESupport,
@@ -110,6 +114,7 @@ __all__ = [
     # Exceptions
     "UnsupportedFeatureError",
     "ProtocolNotImplementedError",
+    "DialectNotAdaptedException",
     # Protocols
     "WindowFunctionSupport",
     "CTESupport",

--- a/src/rhosocial/activerecord/backend/dialect/base.py
+++ b/src/rhosocial/activerecord/backend/dialect/base.py
@@ -70,6 +70,30 @@ class SQLDialectBase:
         """Initialize SQL dialect."""
         # Add strict validation flag with default as True for safety
         self.strict_validation = True
+        # Version is None until introspect_and_adapt() is called
+        self._version: Optional[Tuple[int, int, int]] = None
+
+    @property
+    def version(self) -> Tuple[int, int, int]:
+        """
+        Get dialect version tuple.
+
+        Returns:
+            Version tuple (major, minor, patch).
+
+        Raises:
+            DialectNotAdaptedException: If version hasn't been set via
+                introspect_and_adapt() or explicit assignment.
+        """
+        if self._version is None:
+            from .exceptions import DialectNotAdaptedException
+            raise DialectNotAdaptedException(self.name)
+        return self._version
+
+    @version.setter
+    def version(self, value: Tuple[int, int, int]) -> None:
+        """Set dialect version tuple."""
+        self._version = value
 
     @property
     def name(self) -> str:

--- a/src/rhosocial/activerecord/backend/dialect/exceptions.py
+++ b/src/rhosocial/activerecord/backend/dialect/exceptions.py
@@ -9,6 +9,31 @@ features or haven't implemented required protocols.
 from typing import Optional
 
 
+class DialectNotAdaptedException(Exception):
+    """
+    Raised when a dialect feature is accessed before introspection/adaptation.
+
+    This exception is raised when version-dependent dialect features are accessed
+    before the backend has called introspect_and_adapt() to detect the actual
+    server version and set the dialect version.
+    """
+
+    def __init__(self, dialect_name: str):
+        """
+        Initialize dialect not adapted error.
+
+        Args:
+            dialect_name: Name of the dialect
+        """
+        self.dialect_name = dialect_name
+        message = (
+            f"'{dialect_name}' dialect has not been adapted. "
+            f"Call backend.introspect_and_adapt() or use backend.context() "
+            f"for automatic adaptation."
+        )
+        super().__init__(message)
+
+
 class UnsupportedFeatureError(Exception):
     """
     Raised when a dialect doesn't support a specific feature.

--- a/src/rhosocial/activerecord/backend/impl/dummy/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/dummy/dialect.py
@@ -196,6 +196,12 @@ class DummyDialect(
     Dummy dialect supporting all features for SQL generation testing.
     """
 
+    def __init__(self) -> None:
+        """Initialize dummy dialect with a placeholder version."""
+        super().__init__()
+        # Set a default version since dummy doesn't represent a real database
+        self._version = (1, 0, 0)
+
     # region Protocol Support Checks - Core Features
     def supports_window_functions(self) -> bool:
         return True

--- a/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
@@ -206,16 +206,20 @@ class SQLiteDialect(
     - FILTER clause (since 3.10.0)
     """
 
-    def __init__(self, version: Tuple[int, int, int] = (3, 35, 0)):
+    def __init__(self, version: Optional[Tuple[int, int, int]] = None):
         """
         Initialize SQLite dialect with specific version.
 
         Args:
-            version: SQLite version tuple (major, minor, patch)
+            version: SQLite version tuple (major, minor, patch).
+                If None, the dialect must be adapted via
+                backend.introspect_and_adapt() before version-dependent
+                features can be used.
         """
-        self.version = version
-        self._runtime_params: Dict[str, Any] = {}
         super().__init__()
+        if version is not None:
+            self.version = version
+        self._runtime_params: Dict[str, Any] = {}
 
     def set_runtime_param(self, key: str, value: Any) -> None:
         """Set a runtime parameter (detected after connection)."""

--- a/src/rhosocial/activerecord/backend/impl/sqlite/mixins.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/mixins.py
@@ -71,7 +71,7 @@ class SQLiteExtensionMixin:
             Dictionary mapping extension names to their info
         """
         registry = self._ensure_extension_registry()
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return registry.detect_extensions(version)
 
     def is_extension_available(self, name: str) -> bool:
@@ -84,7 +84,7 @@ class SQLiteExtensionMixin:
             True if extension is available
         """
         registry = self._ensure_extension_registry()
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return registry.is_extension_available(name, version)
 
     def get_extension_info(self, name: str) -> Optional[SQLiteExtensionInfo]:
@@ -97,7 +97,7 @@ class SQLiteExtensionMixin:
             Extension info, or None if not found
         """
         registry = self._ensure_extension_registry()
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return registry.get_extension_info(name, version)
 
     def check_extension_feature(self, ext_name: str, feature_name: str) -> bool:
@@ -111,7 +111,7 @@ class SQLiteExtensionMixin:
             True if feature is available
         """
         registry = self._ensure_extension_registry()
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return registry.check_extension_feature(ext_name, feature_name, version)
 
     def get_supported_extension_features(self, ext_name: str) -> List[str]:
@@ -124,7 +124,7 @@ class SQLiteExtensionMixin:
             List of supported feature names
         """
         registry = self._ensure_extension_registry()
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return registry.get_supported_features(ext_name, version)
 
 
@@ -147,7 +147,7 @@ class SQLitePragmaMixin:
         if info is None:
             return None
 
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         if version < info.min_version:
             return None
 
@@ -209,7 +209,7 @@ class SQLitePragmaMixin:
         if info is None:
             return False
 
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return version >= info.min_version
 
     def get_pragmas_by_category(self, category: PragmaCategory) -> List[PragmaInfo]:
@@ -221,7 +221,7 @@ class SQLitePragmaMixin:
         Returns:
             List of PragmaInfo for pragmas in the category
         """
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return [info for info in get_pragmas_by_category(category) if version >= info.min_version]
 
     def get_all_pragma_infos(self) -> Dict[str, PragmaInfo]:
@@ -230,7 +230,7 @@ class SQLitePragmaMixin:
         Returns:
             Dictionary mapping PRAGMA names to their info
         """
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return {name: info for name, info in get_all_pragma_infos().items() if version >= info.min_version}
 
 
@@ -251,7 +251,7 @@ class SQLiteVirtualTableMixin(SQLiteExtensionMixin):
 
     def supports_virtual_table(self) -> bool:
         """Whether virtual tables are supported."""
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return version >= (3, 8, 8)
 
     def supports_rtree(self) -> bool:
@@ -263,7 +263,7 @@ class SQLiteVirtualTableMixin(SQLiteExtensionMixin):
         compile_options = self.get_runtime_param("compile_options", {})
         if compile_options:
             return "ENABLE_RTREE" in compile_options
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return version >= (3, 6, 0)
 
     def supports_fts5(self) -> bool:
@@ -275,7 +275,7 @@ class SQLiteVirtualTableMixin(SQLiteExtensionMixin):
         compile_options = self.get_runtime_param("compile_options", {})
         if compile_options:
             return "ENABLE_FTS5" in compile_options
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return version >= (3, 9, 0)
 
     def supports_geopoly(self) -> bool:
@@ -287,7 +287,7 @@ class SQLiteVirtualTableMixin(SQLiteExtensionMixin):
         compile_options = self.get_runtime_param("compile_options", {})
         if compile_options:
             return "ENABLE_GEOPOLY" in compile_options
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return version >= (3, 26, 0)
 
     def supports_math_functions(self) -> bool:
@@ -299,7 +299,7 @@ class SQLiteVirtualTableMixin(SQLiteExtensionMixin):
         Returns:
             True if math functions are supported
         """
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         if version >= (3, 35, 0):
             return self.get_runtime_param("math_functions_available", True)
         return False
@@ -315,7 +315,7 @@ class SQLiteVirtualTableMixin(SQLiteExtensionMixin):
         Returns:
             True if json1 extension is available
         """
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         if version >= (3, 38, 0):
             return True
         return self.get_runtime_param("json1_available", False)
@@ -410,7 +410,7 @@ class SQLiteVirtualTableMixin(SQLiteExtensionMixin):
         """Format CREATE VIRTUAL TABLE for R-Tree."""
         from .extension.extensions.rtree import get_rtree_extension
 
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         if version < (3, 6, 0):
             raise UnsupportedFeatureError(
                 getattr(self, "name", "sqlite"), "R-Tree", "R-Tree requires SQLite 3.6.0 or later."
@@ -445,7 +445,7 @@ class SQLiteVirtualTableMixin(SQLiteExtensionMixin):
         """Format CREATE VIRTUAL TABLE for Geopoly."""
         from .extension.extensions.geopoly import get_geopoly_extension
 
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         if version < (3, 26, 0):
             raise UnsupportedFeatureError(
                 getattr(self, "name", "sqlite"), "Geopoly", "Geopoly requires SQLite 3.26.0 or later."
@@ -792,7 +792,7 @@ class SQLiteIntrospectionCapabilityMixin:
         Note: Foreign key constraints are disabled by default and must be
         enabled via 'PRAGMA foreign_keys = ON'.
         """
-        version = getattr(self, "version", (3, 35, 0))
+        version = self.version
         return version >= (3, 6, 19)
 
     def supports_view_introspection(self) -> bool:
@@ -930,12 +930,15 @@ class SQLiteIntrospectionCapabilityMixin:
         include_system = params.get("include_system", False)
         table_type = params.get("table_type")
 
-        # Use PRAGMA table_list for SQLite 3.37.0+
-        if self.supports_table_list_pragma():
+        # Use PRAGMA table_list only when system tables are requested,
+        # since PRAGMA cannot filter them out at the SQL level.
+        # For user-only queries, sqlite_master provides native filtering.
+        if self.supports_table_list_pragma() and include_system:
             sql = f"PRAGMA {schema}.table_list"
             return (sql, ())
 
-        # Fallback to sqlite_master query for older versions
+        # Fallback to sqlite_master query (also used for include_system=False
+        # because sqlite_master supports NOT LIKE filtering natively)
         sql = "SELECT name, type FROM sqlite_master WHERE type IN ('table'"
         if include_views:
             sql += ", 'view'"

--- a/src/rhosocial/activerecord/connection/pool/async_pool.py
+++ b/src/rhosocial/activerecord/connection/pool/async_pool.py
@@ -191,6 +191,7 @@ class AsyncBackendPool:
                     await backend.connect()
                 else:
                     backend.connect()
+                await backend.introspect_and_adapt()
 
             pooled = PooledBackend(
                 backend=backend,
@@ -302,6 +303,7 @@ class AsyncBackendPool:
                     await pooled.backend.connect()
                 else:
                     pooled.backend.connect()
+            await pooled.backend.introspect_and_adapt()
             pooled.is_healthy = True
             logger.debug("Successfully reconnected stale backend in persistent mode")
             return True
@@ -320,6 +322,7 @@ class AsyncBackendPool:
                 await backend.connect()
             else:
                 backend.connect()
+        await backend.introspect_and_adapt()
 
     async def acquire(self, timeout: Optional[float] = None) -> Any:
         """Acquire a Backend instance.

--- a/src/rhosocial/activerecord/connection/pool/sync_pool.py
+++ b/src/rhosocial/activerecord/connection/pool/sync_pool.py
@@ -149,6 +149,7 @@ class BackendPool:
                     if self._is_persistent:
                         try:
                             pooled.backend.connect()
+                            pooled.backend.introspect_and_adapt()
                         except Exception as e:
                             logger.error(f"Failed to connect backend during warmup: {e}")
                             self._stats.total_errors += 1
@@ -317,6 +318,7 @@ class BackendPool:
             if hasattr(pooled.backend, 'disconnect'):
                 pooled.backend.disconnect()
             pooled.backend.connect()
+            pooled.backend.introspect_and_adapt()
             pooled.is_healthy = True
             logger.debug("Successfully reconnected stale backend in persistent mode")
             return True
@@ -389,6 +391,7 @@ class BackendPool:
                     if not self._is_persistent and self.config.auto_connect_on_acquire:
                         try:
                             pooled.backend.connect()
+                            pooled.backend.introspect_and_adapt()
                         except Exception as e:
                             # Connect failed, destroy and try again
                             self._in_use.pop(id(pooled.backend), None)
@@ -408,8 +411,10 @@ class BackendPool:
                             # In persistent mode, connect immediately on creation
                             if self._is_persistent:
                                 pooled.backend.connect()
+                                pooled.backend.introspect_and_adapt()
                             elif self.config.auto_connect_on_acquire:
                                 pooled.backend.connect()
+                                pooled.backend.introspect_and_adapt()
 
                             pooled.mark_used()
                             self._in_use[id(pooled.backend)] = pooled

--- a/tests/rhosocial/activerecord_test/feature/backend/dialect/test_capability_integration.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/dialect/test_capability_integration.py
@@ -84,7 +84,10 @@ def _get_protocol(name):
 @pytest.fixture
 def sqlite_backend():
     from rhosocial.activerecord.backend.impl.sqlite import SQLiteBackend
-    return SQLiteBackend(database=":memory:")
+    backend = SQLiteBackend(database=":memory:")
+    backend.connect()
+    backend.introspect_and_adapt()
+    return backend
 
 
 @pytest.fixture

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite/test_introspect.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite/test_introspect.py
@@ -13,10 +13,12 @@ class TestSQLiteIntrospect:
         backend = SQLiteBackend(database=":memory:")
         backend.connect()
 
-        # Get version before introspection
-        version_before = backend.dialect.version
-        print(f"\nVersion before introspect: {version_before}")
-        print(f"sqlite3.sqlite_version: {sqlite3.sqlite_version}")
+        # Before introspection, accessing version should raise exception
+        from rhosocial.activerecord.backend.dialect.exceptions import DialectNotAdaptedException
+        with pytest.raises(DialectNotAdaptedException):
+            _ = backend.dialect.version
+
+        print(f"\nsqlite3.sqlite_version: {sqlite3.sqlite_version}")
         print(f"sqlite3.sqlite_version_info: {sqlite3.sqlite_version_info}")
 
         # Introspect and adapt
@@ -35,6 +37,7 @@ class TestSQLiteIntrospect:
         """Test that dialect version matches sqlite3 library version."""
         backend = SQLiteBackend(database=":memory:")
         backend.connect()
+        backend.introspect_and_adapt()
 
         print(f"\nDialect version: {backend.dialect.version}")
         print(f"sqlite3.sqlite_version: {sqlite3.sqlite_version}")
@@ -74,15 +77,17 @@ class TestSQLiteIntrospect:
         """Test automatic version detection from actual SQLite library."""
         backend = SQLiteBackend(database=":memory:")
 
-        # Before connect, version might be default
-        print(f"\nVersion before connect: {backend.dialect.version}")
+        # Before connect/introspection, accessing version should raise exception
+        from rhosocial.activerecord.backend.dialect.exceptions import DialectNotAdaptedException
+        with pytest.raises(DialectNotAdaptedException):
+            _ = backend.dialect.version
 
         backend.connect()
 
         # After introspection, version should match actual library
         backend.introspect_and_adapt()
 
-        print(f"Version after introspection: {backend.dialect.version}")
+        print(f"\nVersion after introspection: {backend.dialect.version}")
         print(f"sqlite3.sqlite_version_info: {sqlite3.sqlite_version_info}")
 
         assert backend.dialect.version == sqlite3.sqlite_version_info
@@ -103,11 +108,12 @@ class TestAsyncSQLiteIntrospect:
         print(f"\naiosqlite.sqlite_version: {aiosqlite.sqlite_version}")
         print(f"sqlite3.sqlite_version: {sqlite3.sqlite_version}")
 
-        # Get version before introspection
-        version_before = backend.dialect.version
-        print(f"Version before introspect: {version_before}")
+        # Before introspection, accessing version should raise exception
+        from rhosocial.activerecord.backend.dialect.exceptions import DialectNotAdaptedException
+        with pytest.raises(DialectNotAdaptedException):
+            _ = backend.dialect.version
 
-        # Introspect and adapt (currently empty implementation)
+        # Introspect and adapt
         await backend.introspect_and_adapt()
 
         # Get version after introspection
@@ -125,11 +131,16 @@ class TestAsyncSQLiteIntrospect:
         """Compare version detection methods."""
         backend = AsyncSQLiteBackend(database=":memory:")
 
-        print(f"\nDialect version (before connect): {backend.dialect.version}")
+        # Before connect/introspection, accessing version should raise exception
+        from rhosocial.activerecord.backend.dialect.exceptions import DialectNotAdaptedException
+        with pytest.raises(DialectNotAdaptedException):
+            _ = backend.dialect.version
 
         await backend.connect()
+        await backend.introspect_and_adapt()
 
         import aiosqlite
+        print(f"\nDialect version (after introspect): {backend.dialect.version}")
         print(f"aiosqlite.sqlite_version: {aiosqlite.sqlite_version}")
         print(f"sqlite3.sqlite_version_info: {sqlite3.sqlite_version_info}")
 

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite/test_sqlite_dialect_function_support.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite/test_sqlite_dialect_function_support.py
@@ -14,21 +14,21 @@ class TestSQLiteFunctionSupportBasic:
 
     def test_supports_functions_returns_dict(self):
         """Test that supports_functions returns a dictionary."""
-        dialect = SQLiteDialect()
+        dialect = SQLiteDialect(version=(3, 35, 0))
         result = dialect.supports_functions()
         assert isinstance(result, dict)
         assert len(result) > 0
 
     def test_supports_functions_all_values_are_bool(self):
         """Test that all values in the returned dict are booleans."""
-        dialect = SQLiteDialect()
+        dialect = SQLiteDialect(version=(3, 35, 0))
         result = dialect.supports_functions()
         for func_name, supported in result.items():
             assert isinstance(supported, bool), f"Value for {func_name} is not bool"
 
     def test_core_functions_always_supported(self):
         """Test that core functions are marked as supported."""
-        dialect = SQLiteDialect()
+        dialect = SQLiteDialect(version=(3, 35, 0))
         result = dialect.supports_functions()
         core_functions = ["count", "sum_", "avg", "min_", "max_", "coalesce", "nullif"]
         for func in core_functions:
@@ -41,7 +41,7 @@ class TestSQLiteFunctionSupportVersionDependent:
 
     def test_json_functions_available_in_all_versions(self):
         """Test that JSON functions are available (via extension or built-in)."""
-        dialect = SQLiteDialect()
+        dialect = SQLiteDialect(version=(3, 35, 0))
         result = dialect.supports_functions()
 
         json_functions = ["json", "json_array", "json_object", "json_extract",
@@ -107,7 +107,7 @@ class TestSQLiteFunctionSupportVersionDependent:
 
     def test_always_available_functions(self):
         """Test functions that are available in all SQLite versions."""
-        dialect = SQLiteDialect()
+        dialect = SQLiteDialect(version=(3, 35, 0))
         result = dialect.supports_functions()
 
         always_available = [
@@ -126,7 +126,7 @@ class TestSQLiteFunctionSupportPrivateMethod:
 
     def test_unknown_function_returns_true(self):
         """Test that unknown functions return True (no restriction)."""
-        dialect = SQLiteDialect()
+        dialect = SQLiteDialect(version=(3, 35, 0))
         result = dialect._is_sqlite_function_supported("unknown_function_xyz")
         assert result is True
 
@@ -154,7 +154,7 @@ class TestSQLiteFunctionSupportIntegration:
 
     def test_function_dict_contains_both_core_and_backend_functions(self):
         """Test that the result contains both core and SQLite-specific functions."""
-        dialect = SQLiteDialect()
+        dialect = SQLiteDialect(version=(3, 35, 0))
         result = dialect.supports_functions()
 
         assert any(func in result for func in ["count", "sum", "avg"])

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite2/conftest.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite2/conftest.py
@@ -20,6 +20,7 @@ def sqlite_backend():
     """Provides a SQLiteBackend instance connected to an in-memory database."""
     backend = SQLiteBackend(database=":memory:")
     backend.connect()
+    backend.introspect_and_adapt()
     yield backend
     backend.disconnect()
 

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_dialect_comprehensive.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite2/test_sqlite_dialect_comprehensive.py
@@ -11,9 +11,13 @@ class TestSQLiteDialectComprehensive:
     """Comprehensive tests for SQLiteDialect"""
 
     def test_init_with_default_version(self):
-        """Test initialization with default version"""
+        """Test initialization without version requires adaptation."""
+        from rhosocial.activerecord.backend.dialect.exceptions import DialectNotAdaptedException
+
         dialect = SQLiteDialect()
-        assert dialect.get_server_version() == (3, 35, 0)  # Default version
+        # Without version set, accessing version should raise exception
+        with pytest.raises(DialectNotAdaptedException):
+            dialect.get_server_version()
 
     def test_init_with_custom_version(self):
         """Test initialization with custom version"""

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite3/test_column_mapping.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite3/test_column_mapping.py
@@ -24,6 +24,7 @@ def mapped_table_backend():
     log.info("Setting up in-memory SQLite backend for column mapping test.")
     backend = SQLiteBackend(database=":memory:")
     backend.connect()
+    backend.introspect_and_adapt()
 
     create_table_sql = """
     CREATE TABLE mapped_users (

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite3/test_returning_operations.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite3/test_returning_operations.py
@@ -28,6 +28,7 @@ def returning_backend():
     log.info("Setting up in-memory SQLite backend for RETURNING tests.")
     backend = SQLiteBackend(database=":memory:")
     backend.connect()
+    backend.introspect_and_adapt()
 
     create_table_sql = """
     CREATE TABLE test_users (

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite3/test_sqlite_examples.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite3/test_sqlite_examples.py
@@ -18,6 +18,7 @@ def sqlite_backend():
     """
     backend = SQLiteBackend(database=":memory:")
     backend.connect()
+    backend.introspect_and_adapt()
     yield backend
     backend.disconnect()
 

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite4/conftest.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite4/conftest.py
@@ -37,10 +37,11 @@ def sqlite_backend() -> Generator[SQLiteBackend, None, None]:
     """Create an in-memory SQLite backend for testing.
 
     Yields:
-        SQLiteBackend: Connected SQLite backend instance.
+        SQLiteBackend: Connected SQLite backend instance with introspected dialect.
     """
     backend = SQLiteBackend(database=":memory:")
     backend.connect()
+    backend.introspect_and_adapt()
     yield backend
     backend.disconnect()
 
@@ -53,7 +54,7 @@ def sqlite_file_backend() -> Generator[SQLiteBackend, None, None]:
     cleaned up after the test.
 
     Yields:
-        SQLiteBackend: Connected SQLite backend instance.
+        SQLiteBackend: Connected SQLite backend instance with introspected dialect.
     """
     # Create temporary database file
     fd, db_path = tempfile.mkstemp(suffix=".db")
@@ -61,6 +62,7 @@ def sqlite_file_backend() -> Generator[SQLiteBackend, None, None]:
 
     backend = SQLiteBackend(database=db_path)
     backend.connect()
+    backend.introspect_and_adapt()
 
     yield backend
 

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite4/test_introspection_to_sql.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite4/test_introspection_to_sql.py
@@ -25,7 +25,7 @@ from rhosocial.activerecord.backend.expression.introspection import (
 
 @pytest.fixture
 def sqlite_dialect():
-    return SQLiteDialect()
+    return SQLiteDialect(version=(3, 35, 0))
 
 
 class TestIntrospectionExpressionBase:

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite_async/async_backend.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite_async/async_backend.py
@@ -525,12 +525,10 @@ class AsyncSQLiteBackend(AsyncStorageBackend):
         """Introspect backend and adapt backend instance to actual server capabilities.
 
         For SQLite, the version is determined by the library itself and does not change,
-        so this method performs no additional adaptation. It exists to satisfy the
-        interface contract.
+        so this method only sets the dialect version to the detected SQLite version.
         """
-        # SQLite version is determined by the library, not the database file
-        # No adaptation needed
-        pass
+        version = self.get_server_version()
+        self._dialect.version = version
 
 
 

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite_async/conftest.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite_async/conftest.py
@@ -63,6 +63,7 @@ async def async_sqlite_backend(temp_db_path):
 
     # Connect to the database
     await backend.connect()
+    await backend.introspect_and_adapt()
 
     try:
         yield backend
@@ -76,6 +77,7 @@ async def async_sqlite_memory_backend():
     """Provides an in-memory AsyncSQLiteBackend instance for testing."""
     backend = AsyncSQLiteBackend(database=":memory:")
     await backend.connect()
+    await backend.introspect_and_adapt()
 
     try:
         yield backend

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite_async/test_async_backend_comprehensive.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite_async/test_async_backend_comprehensive.py
@@ -57,6 +57,7 @@ class TestAsyncSQLiteBackendBasic:
         config = SQLiteConnectionConfig(database=temp_db_path)
         backend = AsyncSQLiteBackend(connection_config=config)
         await backend.connect()
+        await backend.introspect_and_adapt()
         yield backend
         await backend.disconnect()
 
@@ -66,6 +67,7 @@ class TestAsyncSQLiteBackendBasic:
         config = SQLiteConnectionConfig(database=":memory:")
         backend = AsyncSQLiteBackend(connection_config=config)
         await backend.connect()
+        await backend.introspect_and_adapt()
         yield backend
         await backend.disconnect()
 
@@ -456,6 +458,7 @@ class TestAsyncExecuteMany:
         config = SQLiteConnectionConfig(database=temp_db_path)
         backend = AsyncSQLiteBackend(connection_config=config)
         await backend.connect()
+        await backend.introspect_and_adapt()
 
         # Create test tables
         options = ExecutionOptions(stmt_type=StatementType.DDL)
@@ -750,6 +753,7 @@ class TestAsyncSQLiteTransaction:
         config = SQLiteConnectionConfig(database=temp_db_path)
         backend = AsyncSQLiteBackend(connection_config=config)
         await backend.connect()
+        await backend.introspect_and_adapt()
 
         # Create test table
         options = ExecutionOptions(stmt_type=StatementType.DDL)
@@ -1198,6 +1202,7 @@ class TestAsyncReturning:
         config = SQLiteConnectionConfig(database=":memory:")
         backend = AsyncSQLiteBackend(connection_config=config)
         await backend.connect()
+        await backend.introspect_and_adapt()
         yield backend
         await backend.disconnect()
 

--- a/tests/rhosocial/activerecord_test/feature/backend/sqlite_async/test_async_returning_operations.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/sqlite_async/test_async_returning_operations.py
@@ -33,6 +33,7 @@ async def async_returning_backend():
     config = SQLiteConnectionConfig(database=":memory:")
     backend = AsyncSQLiteBackend(connection_config=config)
     await backend.connect()
+    await backend.introspect_and_adapt()
 
     # Create test table
     from rhosocial.activerecord.backend.options import ExecutionOptions

--- a/tests/rhosocial/activerecord_test/logging_module/test_crud_summarization.py
+++ b/tests/rhosocial/activerecord_test/logging_module/test_crud_summarization.py
@@ -71,6 +71,8 @@ def article_backend(temp_db, configured_logging):
     """Configure Article model with SQLite backend."""
     # Use SQLiteBackend directly with database path
     backend = SQLiteBackend(database=temp_db)
+    backend.connect()
+    backend.introspect_and_adapt()
     backend.logger = Article.get_logger()
     Article.__backend__ = backend
 


### PR DESCRIPTION

## Description

Introduce `DialectNotAdaptedException` to prevent silent SQL errors when dialect versions don't match actual server capabilities.

**Problem**: Backend dialects had default versions (SQLite `(3, 35, 0)`, MySQL `(8, 0, 0)`, PostgreSQL `(13, 0, 0)`) that could mismatch actual server capabilities, causing:
- Silent SQL errors when using features the server doesn't support
- User confusion when misdiagnosing issues as ORM bugs

**Solution**: Dialects now default to `None` version and throw `DialectNotAdaptedException` at use time (when `supports_*()` methods are called), not at connection time. This provides fast-fail behavior with clear error messages.

**Key Changes**:
- Add `DialectNotAdaptedException` with helpful error message guiding users to call `introspect_and_adapt()`
- `SQLDialectBase.version` becomes a property that raises when `_version is None`
- All concrete dialects (`SQLiteDialect`, `MySQLDialect`, `PostgresDialect`) default `version=None`
- `DummyDialect` sets fixed `_version=(1, 0, 0)` since it has no real database
- Connection pools automatically call `introspect_and_adapt()` on warmup, reconnect, and acquire
- SQLite: Replace 18 `getattr(self, "version", (3,35,0))` with `self.version`
- SQLite: Fix `format_table_list_query` to properly exclude system tables when `include_system=False`
- CI: Install testsuite from git@release/v1.0.0.dev14 instead of PyPI

## Type of change

- [x] `feat`: A new feature
- [ ] `docs`: Documentation only changes
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [x] `chore`: Changes to the build process or auxiliary tools
- [x] `ci`: Changes to our CI configuration files and scripts
- [ ] `build`: Changes that affect the build system or external dependencies
- [ ] `revert`: Reverts a previous commit

## Breaking Change

- [ ] Yes, for end-users (backward-incompatible API changes)
- [x] Yes, for backend developers (internal architectural changes that may affect custom implementations)
- [ ] No breaking changes

**Impact on End-Users:**
No backward-incompatible changes are expected for typical end-user applications. The `context()` and `configure()` methods continue to work as before, automatically calling `introspect_and_adapt()`.

**Impact on Backend Developers (Custom Implementations):**
Custom backend implementations must ensure dialect version is set either:
1. Explicitly via constructor: `MyDialect(version=(X, Y, Z))`
2. Automatically via `introspect_and_adapt()` which sets the version from server detection

If a version-dependent method (`supports_*()`) is called before adaptation, a `DialectNotAdaptedException` will be raised with a clear error message.

## Related Repositories/Packages

- **python-activerecord-mysql**: Requires corresponding changes for `MySQLDialect` version defaults
- **python-activerecord-postgres**: Requires corresponding changes for `PostgresDialect` version defaults

## Testing

- [ ] I have added new tests to cover my changes.
- [x] I have updated existing tests to reflect my changes.
- [x] All existing tests pass.
- [x] This change has been tested on SQLite backend.

**Test Plan:**
- Ran `PYTHONPATH=src pytest tests/` with Python 3.14
- Result: 5557 passed, 6 skipped, 1 deselected

## Checklist

- [x] My code follows the project's code style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added a Changelog fragment.
- [x] I have verified that my changes do not introduce SQL injection vulnerabilities.
- [x] I have checked for potential performance regressions.

## Commits in this PR

1. `fbca054` - feat(backend): dialect version guarding without defaults
2. `4983e1c` - ci: install testsuite from git@release/v1.0.0.dev14 instead of PyPI
