### PR TITLE
fix(relation): relation module fixes and test quality improvement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
           -m benchmark \
           --benchmark-size=small \
           --benchmark-sort=mean \
-          --tb=short | tee benchmark-output.txt
+          --tb=short | tee -a benchmark-output.txt
         python -m pytest \
           --rootdir=. \
           --confcutdir=. \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
       - main
       - 'release/v**'
       - 'maint/**'
+  workflow_dispatch:
 
 jobs:
   test-with-coverage:
@@ -21,6 +22,17 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
+
+    services:
+      redis:
+        image: redis:8.8
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
     - name: Check out the repository
@@ -40,6 +52,10 @@ jobs:
         pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev15#egg=rhosocial-activerecord-testsuite
 
     - name: Run tests with coverage
+      env:
+        REDIS_HOST: localhost
+        REDIS_PORT: 6379
+        REDIS_DB: 0
       run: |
         export PYTHONPATH=src:tests
         coverage run -m pytest tests/
@@ -61,6 +77,17 @@ jobs:
     permissions:
       contents: read
 
+    services:
+      redis:
+        image: redis:7.0
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
     - name: Check out the repository
       uses: actions/checkout@v6
@@ -78,6 +105,10 @@ jobs:
         pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev15#egg=rhosocial-activerecord-testsuite
 
     - name: Run benchmark suite
+      env:
+        REDIS_HOST: localhost
+        REDIS_PORT: 6379
+        REDIS_DB: 0
       run: |
         set -o pipefail
         export PYTHONPATH=src:tests
@@ -88,6 +119,10 @@ jobs:
         print(pathlib.Path(testsuite.__file__).parent)
         PY
         )
+        python -m pytest \
+          tests/benchmark/relation/ \
+          --benchmark-sort=mean \
+          --tb=short | tee -a benchmark-output.txt
         python -m pytest \
           --rootdir=. \
           --confcutdir=. \
@@ -182,7 +217,30 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - python-version: "3.8"
+            redis-version: "6.2"
+          - python-version: "3.9"
+            redis-version: "7.0"
+          - python-version: "3.10"
+            redis-version: "7.2"
+          - python-version: "3.11"
+            redis-version: "7.4"
+          - python-version: "3.12"
+            redis-version: "8.0"
+          - python-version: "3.13"
+            redis-version: "8.2"
+
+    services:
+      redis:
+        image: redis:${{ matrix.redis-version }}
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
     - name: Check out the repository
@@ -206,6 +264,10 @@ jobs:
         pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev15#egg=rhosocial-activerecord-testsuite
 
     - name: Run tests
+      env:
+        REDIS_HOST: localhost
+        REDIS_PORT: 6379
+        REDIS_DB: 0
       run: |
         export PYTHONPATH=src:tests
         python -m pytest tests/
@@ -217,7 +279,22 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: ["3.13t", "3.14t"]
+        include:
+          - python-version: "3.13t"
+            redis-version: "8.4"
+          - python-version: "3.14t"
+            redis-version: "8.6"
+
+    services:
+      redis:
+        image: redis:${{ matrix.redis-version }}
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
     - name: Check out the repository
@@ -241,7 +318,10 @@ jobs:
         pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev15#egg=rhosocial-activerecord-testsuite
 
     - name: Run tests
+      env:
+        REDIS_HOST: localhost
+        REDIS_PORT: 6379
+        REDIS_DB: 0
       run: |
         export PYTHONPATH=src:tests
         python -m pytest tests/
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,7 @@ jobs:
         )
         python -m pytest \
           tests/benchmark/relation/ \
+          -m benchmark_relation \
           --benchmark-sort=mean \
           --tb=short | tee -a benchmark-output.txt
         python -m pytest \

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ coverage.xml
 cover/
 .allure/
 allure-results/
-benchmark*
+/benchmark*
 
 # Translations
 *.mo
@@ -179,6 +179,9 @@ cython_debug/
 
 # Apple macOS
 **/.DS_Store
+
+# Local test configuration (connection profiles, credentials, etc.)
+tests/config/
 
 # Examples
 examples/**

--- a/changelog.d/96.fixed.md
+++ b/changelog.d/96.fixed.md
@@ -1,0 +1,1 @@
+Fix relation descriptors, cache serialization, and ForwardRef state handling

--- a/docs/en_US/relationships/definitions.md
+++ b/docs/en_US/relationships/definitions.md
@@ -175,6 +175,36 @@ posts = await user.posts()
 
 > 💡 **AI Prompt Example**: "How do I define relationships in async models? What's the difference between sync and async relationship access?"
 
+### Sync/Async Descriptor Mixing Is Prohibited
+
+Sync descriptors (`BelongsTo`, `HasOne`, `HasMany`) can only be used with `ActiveRecord` models. Async descriptors (`AsyncBelongsTo`, `AsyncHasOne`, `AsyncHasMany`) can only be used with `AsyncActiveRecord` models. Mixing them raises `TypeError` at class creation time.
+
+```python
+# ❌ Wrong: sync descriptor on async model → TypeError
+class AsyncUser(AsyncActiveRecord):
+    username: str
+    # Raises TypeError: Sync relation descriptor `posts` cannot be used on async model `AsyncUser`
+    posts: ClassVar[HasMany['AsyncPost']] = HasMany(foreign_key='user_id', inverse_of='user')
+
+# ❌ Wrong: async descriptor on sync model → TypeError
+class User(ActiveRecord):
+    username: str
+    # Raises TypeError: Async relation descriptor `posts` cannot be used on sync model `User`
+    posts: ClassVar[AsyncHasMany['Post']] = AsyncHasMany(foreign_key='user_id', inverse_of='user')
+
+# ✅ Correct: sync descriptor on sync model
+class User(ActiveRecord):
+    username: str
+    posts: ClassVar[HasMany['Post']] = HasMany(foreign_key='user_id', inverse_of='user')
+
+# ✅ Correct: async descriptor on async model
+class AsyncUser(AsyncActiveRecord):
+    username: str
+    posts: ClassVar[AsyncHasMany['AsyncPost']] = AsyncHasMany(foreign_key='user_id', inverse_of='user')
+```
+
+> 💡 **AI Prompt Example**: "What happens when sync and async descriptors are mixed? How to avoid type errors in relationship definitions?"
+
 ## Important Notes
 
 **Note**: All relationship descriptors must be declared as `ClassVar` to avoid interfering with Pydantic's field validation.

--- a/docs/zh_CN/relationships/definitions.md
+++ b/docs/zh_CN/relationships/definitions.md
@@ -216,6 +216,36 @@ users = await AsyncUser.query().with_("posts").all()
 
 > 💡 **AI提示词示例**: "同步和异步模型的关系定义有什么区别？如何正确使用异步关系？"
 
+### 禁止同步/异步描述符混用
+
+同步描述符（`BelongsTo`、`HasOne`、`HasMany`）只能用于 `ActiveRecord` 模型，异步描述符（`AsyncBelongsTo`、`AsyncHasOne`、`AsyncHasMany`）只能用于 `AsyncActiveRecord` 模型。混用会在类创建时抛出 `TypeError`。
+
+```python
+# ❌ 错误：同步描述符用于异步模型 → TypeError
+class AsyncUser(AsyncActiveRecord):
+    username: str
+    # 抛出 TypeError: Sync relation descriptor `posts` cannot be used on async model `AsyncUser`
+    posts: ClassVar[HasMany['AsyncPost']] = HasMany(foreign_key='user_id', inverse_of='user')
+
+# ❌ 错误：异步描述符用于同步模型 → TypeError
+class User(ActiveRecord):
+    username: str
+    # 抛出 TypeError: Async relation descriptor `posts` cannot be used on sync model `User`
+    posts: ClassVar[AsyncHasMany['Post']] = AsyncHasMany(foreign_key='user_id', inverse_of='user')
+
+# ✅ 正确：同步描述符用于同步模型
+class User(ActiveRecord):
+    username: str
+    posts: ClassVar[HasMany['Post']] = HasMany(foreign_key='user_id', inverse_of='user')
+
+# ✅ 正确：异步描述符用于异步模型
+class AsyncUser(AsyncActiveRecord):
+    username: str
+    posts: ClassVar[AsyncHasMany['AsyncPost']] = AsyncHasMany(foreign_key='user_id', inverse_of='user')
+```
+
+> 💡 **AI提示词示例**: "同步和异步描述符混用会怎样？如何避免关系定义的类型错误？"
+
 ## inverse_of 参数说明
 
 `inverse_of` 参数用于指定双向关系的另一端名称。正确设置这个参数可以：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ all = [
 test = [
     # Testing framework for unit and integration tests
     # Core framework for running test suites and fixtures
-    "pytest>=7.0.0",
+    "pytest",
 
     # Code coverage measurement tool
     # Measures test coverage and generates coverage reports
@@ -132,15 +132,15 @@ test = [
     "aiofiles>=23.0.0",
 
     # Benchmark integration with pytest
-    "pytest-benchmark>=4.0.0",
+    "pytest-benchmark",
 
     # Coverage integration with pytest
     # Combines pytest and coverage for seamless test coverage reporting
-    "pytest-cov>=4.0.0",
+    "pytest-cov",
 
     # Parallel test execution plugin for pytest
     # Enables faster test execution through parallel processing
-    "pytest-xdist>=3.6.1",
+    "pytest-xdist",
 
     # Pytest plugin for mocking
     # Provides the 'mocker' fixture for patching and mocking objects in tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,7 @@ pythonpath = [".", "src"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 
-addopts = "-ra -q -m 'not benchmark'"
+addopts = "-ra -q -m 'not benchmark and not redis'"
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
@@ -249,6 +249,7 @@ markers = [
     "cte: marks tests for CTE query functionality",
     "aggregate: marks tests for aggregate queries",
     "cache: marks tests for caching mechanisms",
+    "redis: marks RedisCache tests that require a running Redis instance (use -m redis to run)",
     "benchmark: marks tests as performance benchmarks that should be excluded by default",
     "benchmark_sync: marks synchronous benchmark tests",
     "benchmark_async: marks asynchronous benchmark tests",
@@ -260,6 +261,7 @@ markers = [
     "benchmark_transaction: marks transaction benchmark tests",
     "benchmark_mixin: marks mixin benchmark tests",
     "benchmark_fastapi: marks FastAPI benchmark tests",
+    "benchmark_relation: marks relation cache benchmark tests",
 
     # Database backend-specific markers
     "sqlite: marks tests specific to SQLite backend",

--- a/requirements-dev-3.8.txt
+++ b/requirements-dev-3.8.txt
@@ -1,8 +1,7 @@
 # requirements-dev-3.8.txt
 # Testing framework for unit and integration tests
 # Core framework for running test suites and fixtures
-# Version ~=8.3.5 provides stable testing capabilities
-pytest~=8.3.5
+pytest
 pytest-asyncio
 
 # Pytest plugin for mocking
@@ -25,7 +24,10 @@ coverage
 
 # Coverage integration with pytest
 # Combines pytest and coverage for seamless test coverage reporting
-pytest-cov>=4.0.0
+pytest-cov
+
+# MessagePack serialization support for cache backend testing
+msgpack
 
 # Pydantic with email validation support
 # Adds email field validation capabilities to the core framework

--- a/requirements-dev-3.8.txt
+++ b/requirements-dev-3.8.txt
@@ -26,8 +26,8 @@ coverage
 # Combines pytest and coverage for seamless test coverage reporting
 pytest-cov
 
-# MessagePack serialization support for cache backend testing
-msgpack
+# MessagePack cache support is not introduced in this release.
+# Keep source code only for follow-up external cache design.
 
 # Pydantic with email validation support
 # Adds email field validation capabilities to the core framework

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,7 @@
 # requirements-dev.txt
 # Testing framework for unit and integration tests
 # Core framework for running test suites and fixtures
-# Version ~=8.4.2 provides stable testing capabilities
-pytest~=8.4.2
+pytest
 pytest-asyncio
 
 # Pytest plugin for performance benchmarking
@@ -21,8 +20,7 @@ aiofiles>=23.0.0
 
 # Parallel test execution plugin for pytest
 # Enables faster test execution through parallel processing
-# Version ~=3.8.0 provides stable parallel test execution
-pytest-xdist~=3.8.0
+pytest-xdist
 
 # Code coverage measurement tool
 # Measures test coverage and generates coverage reports
@@ -31,7 +29,7 @@ coverage~=7.10.7
 
 # Coverage integration with pytest
 # Combines pytest and coverage for seamless test coverage reporting
-pytest-cov>=4.0.0
+pytest-cov
 
 # Pydantic with email validation support
 # Adds email field validation capabilities to the core framework
@@ -44,6 +42,9 @@ httpx>=0.27
 
 # Redis client library for distributed cache backend testing
 redis
+
+# MessagePack serialization support for cache backend testing
+msgpack
 
 # YAML file processing library
 # Used for configuration file handling and test data

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,11 +40,8 @@ pydantic[email]
 fastapi>=0.110
 httpx>=0.27
 
-# Redis client library for distributed cache backend testing
-redis
-
-# MessagePack serialization support for cache backend testing
-msgpack
+# Redis and MessagePack cache support are not introduced in this release.
+# Keep source code only for follow-up external cache design.
 
 # YAML file processing library
 # Used for configuration file handling and test data

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -42,6 +42,9 @@ pydantic[email]
 fastapi>=0.110
 httpx>=0.27
 
+# Redis client library for distributed cache backend testing
+redis
+
 # YAML file processing library
 # Used for configuration file handling and test data
 # Version ~=6.0.3 provides safe YAML parsing and generation

--- a/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
@@ -1339,11 +1339,17 @@ class SQLiteDialect(
     # max_version: maximum supported version (inclusive), None = no upper limit
     # Reference: https://www.sqlite.org/changes.html
     _SQLITE_FUNCTION_VERSIONS = {
-        # JSON functions - SQLite 3.38.0+ (JSON1 built-in), but functions available via extension earlier
-        "json": (None, None),  # Available since early versions with JSON1 extension
+        # Core JSONExpression factories use -> / ->> operators, available since SQLite 3.38.0.
+        "json_extract": ((3, 38, 0), None),
+        "json_extract_text": ((3, 38, 0), None),
+        "json_build_object": (None, (0, 0, 0)),
+        "json_array_elements": (None, (0, 0, 0)),
+        "json_objectagg": (None, (0, 0, 0)),
+        "json_arrayagg": (None, (0, 0, 0)),
+        # SQLite JSON functions are available since early versions with JSON1 extension.
+        "json": (None, None),
         "json_array": (None, None),
         "json_object": (None, None),
-        "json_extract": (None, None),
         "json_type": (None, None),
         "json_valid": (None, None),
         "json_quote": (None, None),
@@ -1433,7 +1439,7 @@ class SQLiteDialect(
 
         result = {}
         for func_name in core_functions:
-            result[func_name] = True
+            result[func_name] = self._is_sqlite_function_supported(func_name)
 
         sqlite_funcs = getattr(sqlite_functions, "__all__", [])
         for func_name in sqlite_funcs:

--- a/src/rhosocial/activerecord/base/derived_field_mixin.py
+++ b/src/rhosocial/activerecord/base/derived_field_mixin.py
@@ -3,7 +3,7 @@
 Mixin that registers DerivedFieldHandler and provides derived field resolution logic.
 """
 
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import ClassVar, Dict, List
 
 from .derived_field_handler import DerivedFieldHandler
 from .fields import DerivedField
@@ -19,10 +19,6 @@ class DerivedFieldMixin:
     def _apply_derived_to_query(cls, query, derived, extra_derived):
         exprs = cls._resolve_derived(derived, extra_derived)
         if exprs:
-            from ..backend.expression.core import WildcardExpression
-            dialect = cls.backend().dialect
-            if query.select_columns is None:
-                query.select(WildcardExpression(dialect))
             query.select(*exprs, append=True)
 
     @classmethod

--- a/src/rhosocial/activerecord/interface/query.py
+++ b/src/rhosocial/activerecord/interface/query.py
@@ -275,7 +275,7 @@ class IQueryBuilding(Protocol):
     where_clause: Optional[WhereClause]
     order_by_clause: Optional[OrderByClause]
     join_clauses: List[Union[str, type]]
-    select_columns: Optional[List[BaseExpression]]
+    select_columns: List[BaseExpression]
     limit_offset_clause: Optional[LimitOffsetClause]
     group_by_having_clause: Optional[GroupByHavingClause]
     _adapt_params: bool

--- a/src/rhosocial/activerecord/query/active_query.py
+++ b/src/rhosocial/activerecord/query/active_query.py
@@ -68,7 +68,7 @@ class ActiveQuery(
         self.where_clause = None
         self.order_by_clause = None
         self.join_clauses = []
-        self.select_columns = None
+        self.select_columns = [WildcardExpression(self.backend().dialect)]
         self.limit_offset_clause = None
         self.group_by_having_clause = None
         self._adapt_params = True
@@ -83,7 +83,7 @@ class ActiveQuery(
         self._eager_loads = ThreadSafeDict()
 
     def backend(self) -> StorageBackend:
-        """Get the backend for this query with context awareness.
+        """Get storage backend instance with context awareness.
 
         Returns the appropriate backend:
         1. Sync context backend if available
@@ -182,7 +182,7 @@ class ActiveQuery(
         # Use the temporary limit_offset instead of the original one
         query_expr = statements.QueryExpression(
             dialect,
-            select=self.select_columns or [WildcardExpression(dialect)],  # Default to SELECT *
+            select=self.select_columns,
             from_=from_clause,
             where=self.where_clause,
             group_by_having=self.group_by_having_clause,
@@ -232,7 +232,7 @@ class ActiveQuery(
         # Create QueryExpression with all components
         query_expr = statements.QueryExpression(
             dialect,
-            select=self.select_columns or [WildcardExpression(dialect)],  # Default to SELECT *
+            select=self.select_columns,
             from_=self.join_clause if self.join_clause else from_clause,
             where=self.where_clause,
             group_by_having=self.group_by_having_clause,
@@ -408,7 +408,7 @@ class AsyncActiveQuery(
         self.where_clause = None
         self.order_by_clause = None
         self.join_clauses = []
-        self.select_columns = None
+        self.select_columns = [WildcardExpression(self.backend().dialect)]
         self.limit_offset_clause = None
         self.group_by_having_clause = None
         self._adapt_params = True
@@ -522,7 +522,7 @@ class AsyncActiveQuery(
         # Use the temporary limit_offset instead of the original one
         query_expr = statements.QueryExpression(
             dialect,
-            select=self.select_columns or [WildcardExpression(dialect)],  # Default to SELECT *
+            select=self.select_columns,
             from_=from_clause,
             where=self.where_clause,
             group_by_having=self.group_by_having_clause,
@@ -572,7 +572,7 @@ class AsyncActiveQuery(
         # Create QueryExpression with all components
         query_expr = statements.QueryExpression(
             dialect,
-            select=self.select_columns or [WildcardExpression(dialect)],  # Default to SELECT *
+            select=self.select_columns,
             from_=self.join_clause if self.join_clause else from_clause,
             where=self.where_clause,
             group_by_having=self.group_by_having_clause,

--- a/src/rhosocial/activerecord/query/aggregate.py
+++ b/src/rhosocial/activerecord/query/aggregate.py
@@ -330,7 +330,7 @@ class AggregateQueryMixin:
 
             query_expr = statements.QueryExpression(
                 dialect,
-                select=self.select_columns or [WildcardExpression(dialect)],  # Default to SELECT *
+                select=self.select_columns,
                 from_=self.join_clause if self.join_clause else from_clause,
                 where=self.where_clause,
                 group_by_having=self.group_by_having_clause,
@@ -714,7 +714,7 @@ class AsyncAggregateQueryMixin:
 
             query_expr = statements.QueryExpression(
                 dialect,
-                select=self.select_columns or [WildcardExpression(dialect)],  # Default to SELECT *
+                select=self.select_columns,
                 from_=self.join_clause if self.join_clause else from_clause,
                 where=self.where_clause,
                 group_by_having=self.group_by_having_clause,

--- a/src/rhosocial/activerecord/query/base.py
+++ b/src/rhosocial/activerecord/query/base.py
@@ -229,10 +229,14 @@ class BaseQueryMixin(IQueryBuilding):
                 raise TypeError(f"Column must be str or BaseExpression, got {type(col)}")
 
         # If append is True, add to existing selection; otherwise, replace
-        if append and self.select_columns is not None:
+        if append:
             self.select_columns.extend(converted_columns)
         else:
-            self.select_columns = converted_columns if converted_columns else None
+            if converted_columns:
+                self.select_columns = converted_columns
+            else:
+                from ..backend.expression import WildcardExpression
+                self.select_columns = [WildcardExpression(dialect)]
 
         return self
 

--- a/src/rhosocial/activerecord/query/cte_query.py
+++ b/src/rhosocial/activerecord/query/cte_query.py
@@ -75,7 +75,7 @@ class CTEQuery(
         self.where_clause = None
         self.order_by_clause = None
         self.join_clauses = []
-        self.select_columns = None
+        self.select_columns = [WildcardExpression(self.backend().dialect)]
         self.limit_offset_clause = None
         self.group_by_having_clause = None
         self._adapt_params = True
@@ -244,7 +244,7 @@ class CTEQuery(
         # Build the main query using collected conditions from mixins
         main_query_expr = statements.QueryExpression(
             dialect,
-            select=self.select_columns or [WildcardExpression(dialect)],  # Use selected columns or default to SELECT *
+            select=self.select_columns,
             from_=TableExpression(dialect, main_cte_name),  # Reference the specified CTE
             where=self.where_clause,
             group_by_having=self.group_by_having_clause,
@@ -377,7 +377,7 @@ class AsyncCTEQuery(
         self.where_clause = None
         self.order_by_clause = None
         self.join_clauses = []
-        self.select_columns = None
+        self.select_columns = [WildcardExpression(self.backend().dialect)]
         self.limit_offset_clause = None
         self.group_by_having_clause = None
         self._adapt_params = True
@@ -547,7 +547,7 @@ class AsyncCTEQuery(
         # Build the main query using collected conditions from mixins
         main_query_expr = statements.QueryExpression(
             dialect,
-            select=self.select_columns or [WildcardExpression(dialect)],  # Use selected columns or default to SELECT *
+            select=self.select_columns,
             from_=TableExpression(dialect, main_cte_name),  # Reference the specified CTE
             where=self.where_clause,
             group_by_having=self.group_by_having_clause,

--- a/src/rhosocial/activerecord/relation/async_descriptors.py
+++ b/src/rhosocial/activerecord/relation/async_descriptors.py
@@ -322,9 +322,7 @@ class AsyncRelationDescriptor(Generic[U]):
         """
         self.log(logging.DEBUG, f"Creating async relation method for `{self.name}`")
 
-        async def relation_method(*args, **kwargs):
-            if args or kwargs:
-                return self._query.query(instance, *args, **kwargs) if self._query else None
+        async def relation_method():
             return await self._load_relation(instance)
 
         relation_method.clear_cache = lambda: InstanceCache.delete(instance, self.name)
@@ -426,6 +424,8 @@ class AsyncRelationDescriptor(Generic[U]):
         Returns:
             Dict mapping record IDs (using id() function) to their related data
         """
+        if not records:
+            return {}
         self.log(logging.DEBUG, f"Async batch loading `{self.name}` relation for {len(records)} records")
         if self._cached_model is None:
             self.get_related_model(type(records[0]))

--- a/src/rhosocial/activerecord/relation/async_descriptors.py
+++ b/src/rhosocial/activerecord/relation/async_descriptors.py
@@ -172,7 +172,14 @@ class AsyncRelationDescriptor(Generic[U]):
         """
         self.name = name
         self._owner = owner
-        # self._cache.relation_name = name
+
+        from ..interface import IActiveRecord, IAsyncActiveRecord
+        if issubclass(owner, IActiveRecord) and not issubclass(owner, IAsyncActiveRecord):
+            raise TypeError(
+                f"Async relation descriptor `{name}` cannot be used on sync model `{owner.__name__}`. "
+                f"Use BelongsTo/HasMany/HasOne from "
+                f"rhosocial.activerecord.relation.descriptors instead."
+            )
 
         self.log(logging.DEBUG, f"Registering async relation `{name}` with `{owner.__name__}`")
         owner.register_relation(name, self)

--- a/src/rhosocial/activerecord/relation/async_descriptors.py
+++ b/src/rhosocial/activerecord/relation/async_descriptors.py
@@ -394,11 +394,15 @@ class AsyncRelationDescriptor(Generic[U]):
         try:
             self.log(logging.DEBUG, f"Loading async relation `{self.name}` for {type(instance).__name__}")
             data = await self._loader.load(instance) if self._loader else None
-            InstanceCache.set(instance, self.name, data, self._cache_config)
-            return data
         except Exception as e:
             self.log(logging.ERROR, f"Error loading async relation: {e}")
             return None
+
+        try:
+            InstanceCache.set(instance, self.name, data, self._cache_config)
+        except Exception as e:
+            self.log(logging.ERROR, f"Error caching async relation: {e}")
+        return data
 
     async def batch_load(self, records: List[Any], base_query: Optional[IAsyncActiveQuery]) -> Dict[int, Any]:
         """

--- a/src/rhosocial/activerecord/relation/async_descriptors.py
+++ b/src/rhosocial/activerecord/relation/async_descriptors.py
@@ -29,12 +29,15 @@ def _evaluate_forward_ref(ref: Union[str, ForwardRef], owner: Type[Any]) -> Type
     import sys
     import inspect
 
-    # Get calling frame to access local scope
+    # Get calling frame to access local scope.
+    # Must match frame that actually contains ``owner`` in its locals,
+    # not just any frame from the same module (avoid stale test frames).
     frame = inspect.currentframe()
     while frame:
         if owner.__module__ in str(frame.f_code):
             local_context = frame.f_locals
-            break
+            if owner in local_context.values():
+                break
         frame = frame.f_back
     else:
         local_context = {}
@@ -50,24 +53,6 @@ def _evaluate_forward_ref(ref: Union[str, ForwardRef], owner: Type[Any]) -> Type
     context.update(owner_locals)
 
     type_str = ref if isinstance(ref, str) else ref.__forward_arg__
-
-    if isinstance(ref, ForwardRef):
-        # Use official typing_extensions.evaluate_forward_ref if available
-        try:
-            from typing_extensions import evaluate_forward_ref
-
-            return evaluate_forward_ref(ref, owner=owner, globals=context, locals=None)
-        except ImportError:
-            # Fallback: try using get_type_hints instead of direct _evaluate call
-            try:
-                # Create a temporary class with the forward ref to leverage get_type_hints
-                temp_annotations = {"temp": ref}
-                hints = get_type_hints(type("TempClass", (), {"__annotations__": temp_annotations}), globalns=context)
-                return hints.get("temp", ref)
-            except (NameError, AttributeError, TypeError):
-                pass
-
-    # Final fallback: direct evaluation for string references
     return eval(type_str, context, None)
 
 

--- a/src/rhosocial/activerecord/relation/async_descriptors.py
+++ b/src/rhosocial/activerecord/relation/async_descriptors.py
@@ -385,6 +385,13 @@ class AsyncRelationDescriptor(Generic[U]):
         to fetch the data from the database. The loaded data is then cached for future
         access.
 
+        .. note::
+
+           Cache stampede & proactive refresh are intentionally absent from this
+           layer.  The framework provides ``InstanceCache.get_with_meta()`` and
+           ``.set()`` as building blocks.  Application code (timed tasks, middleware,
+           etc.) can use them to implement its own refresh strategy.
+
         Args:
             instance: The model instance for which to load the related data
 

--- a/src/rhosocial/activerecord/relation/async_descriptors.py
+++ b/src/rhosocial/activerecord/relation/async_descriptors.py
@@ -372,10 +372,9 @@ class AsyncRelationDescriptor(Generic[U]):
 
         .. note::
 
-           Cache stampede & proactive refresh are intentionally absent from this
-           layer.  The framework provides ``InstanceCache.get_with_meta()`` and
-           ``.set()`` as building blocks.  Application code (timed tasks, middleware,
-           etc.) can use them to implement its own refresh strategy.
+           External cache metadata and proactive refresh are not introduced in
+           this release.  This layer only performs simple cache read/write via
+           ``InstanceCache.get()`` and ``InstanceCache.set()``.
 
         Args:
             instance: The model instance for which to load the related data

--- a/src/rhosocial/activerecord/relation/cache.py
+++ b/src/rhosocial/activerecord/relation/cache.py
@@ -1,83 +1,31 @@
 # src/rhosocial/activerecord/relation/cache.py
 """
 Caching implementation for relation data.
-Provides configurable caching with TTL and size limits.
+Provides configurable in-memory caching with TTL and size limits.
 
 Backend Architecture
 --------------------
 ``InstanceCache`` is the public proxy that delegates to a pluggable
 ``CacheBackend``.  The default backend is ``InMemoryCache`` (same
-behavior as before).  Call ``InstanceCache.set_backend(...)`` at
-application startup to switch to a distributed backend.
+behavior as before).
 
-Available backends (in :mod:`rhosocial.activerecord.relation.cache_backends`):
+Available backends for this release:
 
 * ``InMemoryCache`` — stores entries as instance attributes
-* ``RedisCache`` — distributed, cross-container key/value store
 
-Cache Stampede & Proactive Refresh
-----------------------------------
-The framework does NOT implement proactive refresh or cache stampede
-protection.  These are application-level concerns because:
-
-1. **Stale reads are a business decision.**  Some data can be served
-   stale (stale-while-revalidate), some must be absolutely fresh.
-   The framework cannot guess which category a relation falls into.
-
-2. **Refresh cadence depends on access patterns.**  Low-frequency
-   relations should not be refreshed on every read; high-frequency
-   ones might need pre-warming.  Only the application knows.
-
-3. **The framework has no background thread.**  It runs entirely
-   in the request path.  Any "proactive" behaviour would degrade
-   the very request it serves.
-
-What the framework provides as building blocks:
-
-* ``InstanceCache.get_with_meta()`` — returns age, origin, TTL so
-  the application can decide whether to refresh.
-* ``InstanceCache.set()`` — updates a cache entry at any time.
-* ``origin`` metadata on ``CacheResult`` — distinguishes which
-  container/process created the entry (useful for distributed
-  refresh ownership).
+Redis, serializer support and metadata-based proactive refresh are
+intentionally not introduced in this release.  The related source code is
+kept for follow-up external cache design, but is not part of this branch's
+public surface.
 
 Capacity Planning
 -----------------
-Cache entries are stored as deserialised Python objects (InMemory) or
-serialised bytes (Redis, etc.).  Estimate memory before enabling caching
-on large or high‑cardinality relations:
+In-memory cache entries are stored as plain Python objects on model
+instances.  A relation returning 10 000 rows can consume megabytes per
+entry, multiplied by distinct parent-relation key pairs.  Monitor cache
+growth or set a TTL to bound it.
 
-* **InMemory** — each cached result set is a plain Python list of model
-  instances.  A relation returning 10 000 rows can consume megabytes
-  *per entry*, multiplied by distinct parent-relation key pairs.
-  Monitor ``InstanceCache`` growth or set a TTL to bound it.
-
-* **Redis / distributed** — serialised bytes add overhead (JSON/pickle
-  framing).  Use ``MEMORY USAGE <key>`` (Redis) or equivalent tools
-  to measure real footprint.  Account for peak‑load key count × size.
-
-The framework applies no built‑in memory cap or eviction policy —
-configure these at the backend level (Redis ``maxmemory`` + ``allkeys-lru``,
-or wrap ``InMemoryCache`` with a size‑limited dict).
-
-Suggested approaches for the application:
-
-+---------------------------+-------------------------------------------+
-| Strategy                 | Implementation                             |
-+===========================+===========================================+
-| Scheduled warm-up        | APScheduler / cron triggers a script that |
-|                           | calls the relation and refreshes cache.   |
-+---------------------------+-------------------------------------------+
-| Read-triggered refresh   | After ``get_with_meta()``, if age >       |
-|                          | threshold and origin matches, call        |
-|                          | loader + ``set()`` (soft inline refresh). |
-+---------------------------+-------------------------------------------+
-| Stale-while-revalidate   | Serve the stale value, asynchronously     |
-|                           | enqueue a refresh task (Celery / thread). |
-+---------------------------+-------------------------------------------+
-| Mutex-based stampede     | Use Redis SETNX to let only one process   |
-| protection               | re-generate the cache while others wait.  |
-+---------------------------+-------------------------------------------+
+The framework applies no built-in memory cap or eviction policy.
 """
 
 from dataclasses import dataclass
@@ -85,7 +33,10 @@ from datetime import datetime, timedelta
 from threading import Lock
 from typing import Any, Optional, Dict, Generic, TypeVar
 
-from .cache_backends import CacheBackend, CacheResult, InMemoryCache
+from .cache_backends import CacheBackend, InMemoryCache
+
+# Not introduced in this release; keep source for follow-up external cache design.
+# from .cache_backends import CacheResult
 
 
 @dataclass
@@ -226,9 +177,8 @@ class InstanceCache(Generic[T]):
         # default (InMemoryCache) — no change needed
         value = InstanceCache.get(instance, "posts", config)
 
-        # switch globally to Redis
-        from rhosocial.activerecord.relation.cache_backends import RedisCache
-        InstanceCache.set_backend(RedisCache(...))
+        # switch globally to another CacheBackend implementation
+        InstanceCache.set_backend(custom_backend)
     """
 
     _backend: CacheBackend = InMemoryCache()
@@ -299,41 +249,26 @@ class InstanceCache(Generic[T]):
         """
         InstanceCache._backend.set(instance, relation_name, value, config)
 
-    @staticmethod
-    def get_with_meta(
-        instance: Any, relation_name: str, config: CacheConfig
-    ) -> Optional[CacheResult[T]]:
-        """Get cached relation value with metadata.
-
-        Returns a ``CacheResult`` that includes age, origin and TTL info
-        when the active backend supports it.  Falls back to a basic result
-        when the backend only exposes the plain ``get()`` interface.
-
-        Args:
-            instance: Model instance
-            relation_name: Name of the relation
-            config: Cache configuration
-
-        Returns:
-            ``CacheResult`` with value and metadata, or None on miss/expiry
-        """
-        backend = InstanceCache._backend
-
-        # Prefer rich metadata path (RedisCache with record_origin=True)
-        getter = getattr(backend, "get_with_meta", None)
-        if getter is not None:
-            return getter(instance, relation_name, config)
-
-        # Fallback: plain get() — can only provide value + backend origin
-        value = backend.get(instance, relation_name, config)
-        if value is None:
-            return None
-        return CacheResult(
-            value=value,
-            age=0.0,
-            origin=backend.origin,
-            ttl=config.ttl,
-        )
+    # Not introduced in this release; keep the metadata path for follow-up
+    # external cache design, where CacheResult/origin semantics will be settled.
+    # @staticmethod
+    # def get_with_meta(
+    #     instance: Any, relation_name: str, config: CacheConfig
+    # ) -> Optional[CacheResult[T]]:
+    #     """Get cached relation value with metadata."""
+    #     backend = InstanceCache._backend
+    #     getter = getattr(backend, "get_with_meta", None)
+    #     if getter is not None:
+    #         return getter(instance, relation_name, config)
+    #     value = backend.get(instance, relation_name, config)
+    #     if value is None:
+    #         return None
+    #     return CacheResult(
+    #         value=value,
+    #         age=0.0,
+    #         origin=backend.origin,
+    #         ttl=config.ttl,
+    #     )
 
     @staticmethod
     def delete(instance: Any, relation_name: str, config: Optional[CacheConfig] = None):

--- a/src/rhosocial/activerecord/relation/cache.py
+++ b/src/rhosocial/activerecord/relation/cache.py
@@ -2,12 +2,71 @@
 """
 Caching implementation for relation data.
 Provides configurable caching with TTL and size limits.
+
+Backend Architecture
+--------------------
+``InstanceCache`` is the public proxy that delegates to a pluggable
+``CacheBackend``.  The default backend is ``InMemoryCache`` (same
+behavior as before).  Call ``InstanceCache.set_backend(...)`` at
+application startup to switch to a distributed backend.
+
+Available backends (in :mod:`rhosocial.activerecord.relation.cache_backends`):
+
+* ``InMemoryCache`` — stores entries as instance attributes
+* ``RedisCache`` — distributed, cross-container key/value store
+
+Cache Stampede & Proactive Refresh
+----------------------------------
+The framework does NOT implement proactive refresh or cache stampede
+protection.  These are application-level concerns because:
+
+1. **Stale reads are a business decision.**  Some data can be served
+   stale (stale-while-revalidate), some must be absolutely fresh.
+   The framework cannot guess which category a relation falls into.
+
+2. **Refresh cadence depends on access patterns.**  Low-frequency
+   relations should not be refreshed on every read; high-frequency
+   ones might need pre-warming.  Only the application knows.
+
+3. **The framework has no background thread.**  It runs entirely
+   in the request path.  Any "proactive" behaviour would degrade
+   the very request it serves.
+
+What the framework provides as building blocks:
+
+* ``InstanceCache.get_with_meta()`` — returns age, origin, TTL so
+  the application can decide whether to refresh.
+* ``InstanceCache.set()`` — updates a cache entry at any time.
+* ``origin`` metadata on ``CacheResult`` — distinguishes which
+  container/process created the entry (useful for distributed
+  refresh ownership).
+
+Suggested approaches for the application:
+
++---------------------------+-------------------------------------------+
+| Strategy                 | Implementation                             |
++===========================+===========================================+
+| Scheduled warm-up        | APScheduler / cron triggers a script that |
+|                           | calls the relation and refreshes cache.   |
++---------------------------+-------------------------------------------+
+| Read-triggered refresh   | After ``get_with_meta()``, if age >       |
+|                          | threshold and origin matches, call        |
+|                          | loader + ``set()`` (soft inline refresh). |
++---------------------------+-------------------------------------------+
+| Stale-while-revalidate   | Serve the stale value, asynchronously     |
+|                           | enqueue a refresh task (Celery / thread). |
++---------------------------+-------------------------------------------+
+| Mutex-based stampede     | Use Redis SETNX to let only one process   |
+| protection               | re-generate the cache while others wait.  |
++---------------------------+-------------------------------------------+
 """
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from threading import Lock
 from typing import Any, Optional, Dict, Generic, TypeVar
+
+from .cache_backends import CacheBackend, CacheResult, InMemoryCache
 
 
 @dataclass
@@ -139,10 +198,26 @@ class InstanceCache(Generic[T]):
     """
     Instance-level cache management system.
 
-    Instead of using a shared cache at the descriptor level, this system
-    stores cache data directly on each model instance, ensuring proper
-    isolation between instances.
+    Delegates to a pluggable ``CacheBackend``.  By default uses
+    ``InMemoryCache``, which stores data on the model instance
+    as before — fully backward compatible.
+
+    Usage::
+
+        # default (InMemoryCache) — no change needed
+        value = InstanceCache.get(instance, "posts", config)
+
+        # switch globally to Redis
+        from rhosocial.activerecord.relation.cache_backends import RedisCache
+        InstanceCache.set_backend(RedisCache(...))
     """
+
+    _backend: CacheBackend = InMemoryCache()
+
+    @classmethod
+    def set_backend(cls, backend: CacheBackend) -> None:
+        """Replace the active cache backend (affects all instances)."""
+        cls._backend = backend
 
     @staticmethod
     def get_cache_attr_name(relation_name: str) -> str:
@@ -159,6 +234,10 @@ class InstanceCache(Generic[T]):
     @staticmethod
     def get_instance_cache(instance: Any, relation_name: str) -> Dict:
         """Get or create cache dict on the instance.
+
+        .. deprecated::
+            Only used by ``InMemoryCache``.  Prefer using ``InstanceCache.get``
+            directly for backend-agnostic access.
 
         Args:
             instance: Model instance
@@ -177,7 +256,7 @@ class InstanceCache(Generic[T]):
 
     @staticmethod
     def get(instance: Any, relation_name: str, config: CacheConfig) -> Optional[T]:
-        """Get cached relation value from the instance.
+        """Get cached relation value via the active backend.
 
         Args:
             instance: Model instance
@@ -187,24 +266,11 @@ class InstanceCache(Generic[T]):
         Returns:
             Cached value or None if not found or expired
         """
-        if not config.enabled:
-            return None
-
-        cache = InstanceCache.get_instance_cache(instance, relation_name)
-
-        if "entry" not in cache:
-            return None
-
-        entry = cache["entry"]
-        if entry.is_expired():
-            del cache["entry"]
-            return None
-
-        return entry.value
+        return InstanceCache._backend.get(instance, relation_name, config)
 
     @staticmethod
     def set(instance: Any, relation_name: str, value: T, config: CacheConfig) -> None:
-        """Store relation value in the instance cache.
+        """Store relation value via the active backend.
 
         Args:
             instance: Model instance
@@ -212,27 +278,51 @@ class InstanceCache(Generic[T]):
             value: Value to cache
             config: Cache configuration
         """
-        if not config.enabled:
-            return
+        InstanceCache._backend.set(instance, relation_name, value, config)
 
-        cache = InstanceCache.get_instance_cache(instance, relation_name)
-        cache["entry"] = CacheEntry(value, config.ttl)
+    @staticmethod
+    def get_with_meta(
+        instance: Any, relation_name: str, config: CacheConfig
+    ) -> Optional[CacheResult[T]]:
+        """Get cached relation value with metadata.
+
+        Returns a ``CacheResult`` that includes age, origin and TTL info
+        when the active backend supports it.  Falls back to a basic result
+        when the backend only exposes the plain ``get()`` interface.
+
+        Args:
+            instance: Model instance
+            relation_name: Name of the relation
+            config: Cache configuration
+
+        Returns:
+            ``CacheResult`` with value and metadata, or None on miss/expiry
+        """
+        backend = InstanceCache._backend
+
+        # Prefer rich metadata path (RedisCache with record_origin=True)
+        getter = getattr(backend, "get_with_meta", None)
+        if getter is not None:
+            return getter(instance, relation_name, config)
+
+        # Fallback: plain get() — can only provide value + backend origin
+        value = backend.get(instance, relation_name, config)
+        if value is None:
+            return None
+        return CacheResult(
+            value=value,
+            age=0.0,
+            origin=backend.origin,
+            ttl=config.ttl,
+        )
 
     @staticmethod
     def delete(instance: Any, relation_name: str, config: Optional[CacheConfig] = None):
-        """Remove cached relation value from the instance.
+        """Remove cached relation value via the active backend.
 
         Args:
             instance: Model instance
             relation_name: Name of the relation
             config: Cache configuration (optional, if provided and disabled, no action taken)
         """
-        if config is not None and not config.enabled:
-            return
-
-        cache_attr = InstanceCache.get_cache_attr_name(relation_name)
-
-        if hasattr(instance, cache_attr):
-            cache = getattr(instance, cache_attr)
-            if "entry" in cache:
-                del cache["entry"]
+        InstanceCache._backend.delete(instance, relation_name, config)

--- a/src/rhosocial/activerecord/relation/cache.py
+++ b/src/rhosocial/activerecord/relation/cache.py
@@ -41,6 +41,25 @@ What the framework provides as building blocks:
   container/process created the entry (useful for distributed
   refresh ownership).
 
+Capacity Planning
+-----------------
+Cache entries are stored as deserialised Python objects (InMemory) or
+serialised bytes (Redis, etc.).  Estimate memory before enabling caching
+on large or high‑cardinality relations:
+
+* **InMemory** — each cached result set is a plain Python list of model
+  instances.  A relation returning 10 000 rows can consume megabytes
+  *per entry*, multiplied by distinct parent-relation key pairs.
+  Monitor ``InstanceCache`` growth or set a TTL to bound it.
+
+* **Redis / distributed** — serialised bytes add overhead (JSON/pickle
+  framing).  Use ``MEMORY USAGE <key>`` (Redis) or equivalent tools
+  to measure real footprint.  Account for peak‑load key count × size.
+
+The framework applies no built‑in memory cap or eviction policy —
+configure these at the backend level (Redis ``maxmemory`` + ``allkeys-lru``,
+or wrap ``InMemoryCache`` with a size‑limited dict).
+
 Suggested approaches for the application:
 
 +---------------------------+-------------------------------------------+

--- a/src/rhosocial/activerecord/relation/cache_backend.py
+++ b/src/rhosocial/activerecord/relation/cache_backend.py
@@ -3,12 +3,12 @@
 Backward-compat re-export.  New code should import directly from
 ``rhosocial.activerecord.relation.cache_backends``.
 """
-from .cache_backends import CacheBackend, CacheSerializer, InMemoryCache, RedisCache, RedisConfig, T
+from .cache_backends import CacheBackend, InMemoryCache, T
+
+# Not introduced in this release; keep source for follow-up external cache design.
+# from .cache_backends import CacheSerializer, RedisCache, RedisConfig
 
 __all__ = [
     "CacheBackend",
-    "CacheSerializer",
     "InMemoryCache",
-    "RedisCache",
-    "RedisConfig",
 ]

--- a/src/rhosocial/activerecord/relation/cache_backend.py
+++ b/src/rhosocial/activerecord/relation/cache_backend.py
@@ -1,0 +1,14 @@
+# src/rhosocial/activerecord/relation/cache_backend.py
+"""
+Backward-compat re-export.  New code should import directly from
+``rhosocial.activerecord.relation.cache_backends``.
+"""
+from .cache_backends import CacheBackend, CacheSerializer, InMemoryCache, RedisCache, RedisConfig, T
+
+__all__ = [
+    "CacheBackend",
+    "CacheSerializer",
+    "InMemoryCache",
+    "RedisCache",
+    "RedisConfig",
+]

--- a/src/rhosocial/activerecord/relation/cache_backends/__init__.py
+++ b/src/rhosocial/activerecord/relation/cache_backends/__init__.py
@@ -1,0 +1,22 @@
+# src/rhosocial/activerecord/relation/cache_backends/__init__.py
+"""
+Pluggable cache backends for relation data caching.
+
+Available backends:
+
+* ``InMemoryCache`` — stores entries as instance attributes (default)
+* ``RedisCache`` — distributed, cross-container key/value store
+"""
+
+from ._protocol import CacheBackend, CacheResult, CacheSerializer, T
+from .in_memory import InMemoryCache
+from .redis import RedisCache, RedisConfig
+
+__all__ = [
+    "CacheBackend",
+    "CacheResult",
+    "CacheSerializer",
+    "InMemoryCache",
+    "RedisCache",
+    "RedisConfig",
+]

--- a/src/rhosocial/activerecord/relation/cache_backends/__init__.py
+++ b/src/rhosocial/activerecord/relation/cache_backends/__init__.py
@@ -2,21 +2,22 @@
 """
 Pluggable cache backends for relation data caching.
 
-Available backends:
+Available backends for this release:
 
 * ``InMemoryCache`` — stores entries as instance attributes (default)
-* ``RedisCache`` — distributed, cross-container key/value store
+
+Redis and serializer support are intentionally not introduced in this release.
+The implementation files are kept in-tree for follow-up external cache design.
 """
 
-from ._protocol import CacheBackend, CacheResult, CacheSerializer, T
+from ._protocol import CacheBackend, T
 from .in_memory import InMemoryCache
-from .redis import RedisCache, RedisConfig
+
+# Not introduced in this release; keep source for follow-up external cache design.
+# from ._protocol import CacheResult, CacheSerializer
+# from .redis import RedisCache, RedisConfig
 
 __all__ = [
     "CacheBackend",
-    "CacheResult",
-    "CacheSerializer",
     "InMemoryCache",
-    "RedisCache",
-    "RedisConfig",
 ]

--- a/src/rhosocial/activerecord/relation/cache_backends/_protocol.py
+++ b/src/rhosocial/activerecord/relation/cache_backends/_protocol.py
@@ -2,12 +2,12 @@
 """
 Abstract definitions for pluggable cache backends.
 
-Provides:
+Provides for this release:
 - ``CacheBackend`` — protocol that every backend must implement
-- ``CacheSerializer`` — JSON-based serializer (default), with msgpack and
-  pickle alternatives
-- ``CacheResult`` — value + metadata returned by backends that support
-  proactive refresh (origin, age, TTL)
+
+Not introduced in this release:
+- ``CacheSerializer`` — kept in source for follow-up external cache design
+- ``CacheResult`` — kept in source for follow-up metadata/origin design
 """
 
 from __future__ import annotations
@@ -127,6 +127,29 @@ class CacheBackend(Protocol[T]):
         ...
 
 
+def _msgpack_default(value: Any) -> Any:
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    if isinstance(value, timedelta):
+        return value.total_seconds()
+    if isinstance(value, Enum):
+        return {"__cache_type__": "enum", "value": value.name}
+    if isinstance(value, set):
+        return {"__cache_type__": "set", "value": list(value)}
+    if isinstance(value, complex):
+        return {"__cache_type__": "complex", "value": [value.real, value.imag]}
+    if isinstance(value, range):
+        return {"__cache_type__": "range", "value": [value.start, value.stop, value.step]}
+    raise TypeError(f"can not serialize {type(value).__name__!r} object")
+
+
+def _msgpack_object_hook(value: Dict[Any, Any]) -> Dict[Any, Any]:
+    marker = value.get("__cache_type__")
+    if marker is not None:
+        raise TypeError(f"msgpack cache serializer does not support {marker!r} values")
+    return value
+
+
 class CacheSerializer:
     """Serializer for cache values.
 
@@ -201,7 +224,7 @@ class CacheSerializer:
             return json.dumps(value, cls=_EnhancedJSONEncoder, ensure_ascii=False).encode("utf-8")
         elif self._format == self.FORMAT_MSGPACK:
             import msgpack
-            return msgpack.dumps(value)
+            return msgpack.dumps(value, default=_msgpack_default)
         else:
             return pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
 
@@ -210,6 +233,6 @@ class CacheSerializer:
             return json.loads(data.decode("utf-8"))
         elif self._format == self.FORMAT_MSGPACK:
             import msgpack
-            return msgpack.loads(data)
+            return msgpack.loads(data, object_hook=_msgpack_object_hook)
         else:
             return pickle.loads(data)

--- a/src/rhosocial/activerecord/relation/cache_backends/_protocol.py
+++ b/src/rhosocial/activerecord/relation/cache_backends/_protocol.py
@@ -4,21 +4,54 @@ Abstract definitions for pluggable cache backends.
 
 Provides:
 - ``CacheBackend`` — protocol that every backend must implement
-- ``CacheSerializer`` — default pickle-based serializer (used by RedisCache)
+- ``CacheSerializer`` — JSON-based serializer (default), with msgpack and
+  pickle alternatives
 - ``CacheResult`` — value + metadata returned by backends that support
   proactive refresh (origin, age, TTL)
 """
 
 from __future__ import annotations
 
+import json
+import logging
 import pickle
+import warnings
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Generic, Optional, Protocol, TypeVar
+from datetime import datetime, date, time, timedelta
+from enum import Enum
+from typing import (TYPE_CHECKING, Any, Callable, Dict, Generic, Optional,
+                    Protocol, TypeVar, Union)
 
 if TYPE_CHECKING:
     from ..cache import CacheConfig
 
 T = TypeVar("T")
+
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
+
+logger = logging.getLogger(__name__)
+
+
+class _EnhancedJSONEncoder(json.JSONEncoder):
+    """JSON encoder that handles common Python types beyond the standard set."""
+    def default(self, o: Any) -> Any:
+        if isinstance(o, (datetime, date)):
+            return {"__type__": "datetime", "value": o.isoformat()}
+        if isinstance(o, time):
+            return {"__type__": "time", "value": o.isoformat()}
+        if isinstance(o, timedelta):
+            return {"__type__": "timedelta", "value": o.total_seconds()}
+        if isinstance(o, Enum):
+            return {"__type__": "enum", "module": type(o).__module__, "class": type(o).__qualname__, "value": o.name}
+        if isinstance(o, bytes):
+            return {"__type__": "bytes", "value": o.hex()}
+        if isinstance(o, set):
+            return {"__type__": "set", "value": list(o)}
+        if isinstance(o, complex):
+            return {"__type__": "complex", "value": [o.real, o.imag]}
+        if isinstance(o, range):
+            return {"__type__": "range", "value": [o.start, o.stop, o.step]}
+        return super().default(o)
 
 
 @dataclass
@@ -95,15 +128,88 @@ class CacheBackend(Protocol[T]):
 
 
 class CacheSerializer:
-    """Default serializer for remote cache backends.
+    """Serializer for cache values.
 
-    Uses pickle for flexibility. Can be subclassed to use JSON + type mapping.
+    Default format is **JSON**, which is safe, cross-language, and
+    human-readable.  Two alternative formats are available:
+
+    * ``format="msgpack"`` — faster encoding/decoding and smaller payloads.
+      Requires the ``msgpack`` package.
+    * ``format="pickle"`` — supports arbitrary Python objects.
+      **UNSAFE** — deserialising untrusted data can execute arbitrary code.
+      Only use in trusted environments with known data.
+
+    The JSON encoder handles ``datetime``, ``date``, ``time``,
+    ``timedelta``, ``Enum``, ``bytes`` (hex), ``set`` (as list),
+    ``complex``, and ``range`` out of the box.
+
+    Usage::
+
+        # default (JSON)
+        ser = CacheSerializer()
+        data = ser.serialize({"key": datetime.now()})
+        restored = ser.deserialize(data)
+
+        # msgpack (faster)
+        ser = CacheSerializer(format="msgpack")
+
+        # pickle (UNSAFE, trusted env only)
+        ser = CacheSerializer(format="pickle")
     """
 
-    @staticmethod
-    def serialize(value: Any) -> bytes:
-        return pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+    FORMAT_JSON = "json"
+    FORMAT_MSGPACK = "msgpack"
+    FORMAT_PICKLE = "pickle"
 
-    @staticmethod
-    def deserialize(data: bytes) -> Any:
-        return pickle.loads(data)
+    _FORMATS: Dict[str, str] = {
+        "json": FORMAT_JSON,
+        "msgpack": FORMAT_MSGPACK,
+        "pickle": FORMAT_PICKLE,
+    }
+
+    def __init__(self, format: str = "json"):
+        normalized = self._FORMATS.get(format.lower())
+        if normalized is None:
+            raise ValueError(
+                f"Unknown serializer format {format!r}. "
+                f"Choose from: {', '.join(self._FORMATS)}"
+            )
+        self._format = normalized
+        if normalized == self.FORMAT_MSGPACK:
+            try:
+                import msgpack  # noqa: F401
+            except ImportError:
+                raise ImportError(
+                    "msgpack format requires the 'msgpack' package. "
+                    "Install it with: pip install msgpack"
+                )
+        elif normalized == self.FORMAT_PICKLE:
+            warnings.warn(
+                "Pickle deserialization is unsafe. Only use this format "
+                "in trusted environments with known data sources. "
+                "JSON is the recommended default.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    @property
+    def format(self) -> str:
+        return self._format
+
+    def serialize(self, value: Any) -> bytes:
+        if self._format == self.FORMAT_JSON:
+            return json.dumps(value, cls=_EnhancedJSONEncoder, ensure_ascii=False).encode("utf-8")
+        elif self._format == self.FORMAT_MSGPACK:
+            import msgpack
+            return msgpack.dumps(value)
+        else:
+            return pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+
+    def deserialize(self, data: bytes) -> Any:
+        if self._format == self.FORMAT_JSON:
+            return json.loads(data.decode("utf-8"))
+        elif self._format == self.FORMAT_MSGPACK:
+            import msgpack
+            return msgpack.loads(data)
+        else:
+            return pickle.loads(data)

--- a/src/rhosocial/activerecord/relation/cache_backends/_protocol.py
+++ b/src/rhosocial/activerecord/relation/cache_backends/_protocol.py
@@ -1,0 +1,109 @@
+# src/rhosocial/activerecord/relation/cache_backends/_protocol.py
+"""
+Abstract definitions for pluggable cache backends.
+
+Provides:
+- ``CacheBackend`` — protocol that every backend must implement
+- ``CacheSerializer`` — default pickle-based serializer (used by RedisCache)
+- ``CacheResult`` — value + metadata returned by backends that support
+  proactive refresh (origin, age, TTL)
+"""
+
+from __future__ import annotations
+
+import pickle
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Generic, Optional, Protocol, TypeVar
+
+if TYPE_CHECKING:
+    from ..cache import CacheConfig
+
+T = TypeVar("T")
+
+
+@dataclass
+class CacheResult(Generic[T]):
+    """Cache entry with metadata used for user-driven refresh decisions.
+
+    The framework provides metadata but does NOT implement automatic
+    proactive refresh or cache stampede protection — those are
+    application-level concerns:
+
+    * ``age`` — how long this entry has existed.  Application code can
+      compare against TTL to decide whether a refresh is warranted.
+    * ``origin`` — which container/process created the entry.  In a
+      distributed setup the application can use this to assign refresh
+      responsibility to a single owner.
+    * ``ttl`` — the TTL that was set when the entry was stored.
+
+    Example usage in a scheduled warm-up job::
+
+        result = InstanceCache.get_with_meta(instance, "posts", config)
+        if result is not None and result.age > 0.8 * result.ttl:
+            fresh_data = loader.load(instance)
+            InstanceCache.set(instance, "posts", fresh_data, config)
+
+    Attributes:
+        value: The cached value.
+        age: Seconds since the entry was created.
+        origin: Identifier of the origin that created this entry, or None.
+        ttl: TTL in seconds that was applied when the entry was stored.
+    """
+
+    value: T
+    age: float = 0.0
+    origin: Optional[str] = None
+    ttl: Optional[int] = None
+
+
+class CacheBackend(Protocol[T]):
+    """Cache backend protocol for relation data.
+
+    Implementations must provide get/set/delete.
+    The ``instance`` parameter is the model instance that owns the relation.
+    """
+
+    @property
+    def origin(self) -> Optional[str]:
+        """Return this backend's origin identifier, or None if unknown."""
+        ...
+
+    def get(
+        self,
+        instance: Any,
+        relation_name: str,
+        config: CacheConfig,
+    ) -> Optional[T]:
+        ...
+
+    def set(
+        self,
+        instance: Any,
+        relation_name: str,
+        value: T,
+        config: CacheConfig,
+    ) -> None:
+        ...
+
+    def delete(
+        self,
+        instance: Any,
+        relation_name: str,
+        config: Optional[CacheConfig] = None,
+    ) -> None:
+        ...
+
+
+class CacheSerializer:
+    """Default serializer for remote cache backends.
+
+    Uses pickle for flexibility. Can be subclassed to use JSON + type mapping.
+    """
+
+    @staticmethod
+    def serialize(value: Any) -> bytes:
+        return pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+
+    @staticmethod
+    def deserialize(data: bytes) -> Any:
+        return pickle.loads(data)

--- a/src/rhosocial/activerecord/relation/cache_backends/in_memory.py
+++ b/src/rhosocial/activerecord/relation/cache_backends/in_memory.py
@@ -1,0 +1,62 @@
+# src/rhosocial/activerecord/relation/cache_backends/in_memory.py
+"""
+In-memory cache backend.
+
+Stores ``CacheEntry`` objects as instance attributes
+(``_relation_cache_{name}["entry"]``), matching the original
+``InstanceCache`` behavior exactly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..cache import CacheConfig
+
+
+class InMemoryCache:
+    """In-memory cache using instance attributes."""
+
+    @property
+    def origin(self) -> None:
+        """InMemoryCache has no origin tracking."""
+        return None
+
+    @staticmethod
+    def get_cache_attr_name(relation_name: str) -> str:
+        return f"_relation_cache_{relation_name}"
+
+    def get(self, instance: Any, relation_name: str, config: "CacheConfig"):
+        if not config.enabled:
+            return None
+        cache = self._get_cache(instance, relation_name)
+        if "entry" not in cache:
+            return None
+        entry = cache["entry"]
+        if entry.is_expired():
+            del cache["entry"]
+            return None
+        return entry.value
+
+    def set(self, instance: Any, relation_name: str, value: Any, config: "CacheConfig"):
+        if not config.enabled:
+            return
+        from ..cache import CacheEntry
+        cache = self._get_cache(instance, relation_name)
+        cache["entry"] = CacheEntry(value, config.ttl)
+
+    def delete(self, instance: Any, relation_name: str, config: "CacheConfig" = None):
+        if config is not None and not config.enabled:
+            return
+        attr = self.get_cache_attr_name(relation_name)
+        if hasattr(instance, attr):
+            cache = getattr(instance, attr)
+            if "entry" in cache:
+                del cache["entry"]
+
+    def _get_cache(self, instance: Any, relation_name: str):
+        attr = self.get_cache_attr_name(relation_name)
+        if not hasattr(instance, attr):
+            setattr(instance, attr, {})
+        return getattr(instance, attr)

--- a/src/rhosocial/activerecord/relation/cache_backends/redis.py
+++ b/src/rhosocial/activerecord/relation/cache_backends/redis.py
@@ -1,0 +1,219 @@
+# src/rhosocial/activerecord/relation/cache_backends/redis.py
+"""
+Redis-backed distributed cache backend.
+
+Key format: ``{prefix}{model_name}:{pk_value}:{relation_name}``
+
+When ``record_origin=True``, each value is wrapped in a JSON envelope
+with origin hostname and timestamp for observability.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import socket
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
+
+from ._protocol import CacheSerializer
+
+if TYPE_CHECKING:
+    from ..cache import CacheConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RedisConfig:
+    """Connection configuration for RedisCache.
+
+    Usage::
+
+        # explicit (recommended for production)
+        config = RedisConfig(host="10.0.1.5", port=16379, password="secret")
+
+        # from environment (REDIS_HOST / REDIS_PORT / REDIS_PASSWORD / …)
+        # Use with care: picks up whatever REDIS_* vars happen to be set.
+        # Mainly intended for testing and CI.
+        config = RedisConfig.from_env()
+    """
+
+    host: str = "localhost"
+    port: int = 6379
+    password: Optional[str] = None
+    db: int = 0
+    prefix: str = "ar:cache:"
+    socket_connect_timeout: int = 5
+
+    @classmethod
+    def from_env(cls, prefix: str = "REDIS_") -> RedisConfig:
+        return cls(
+            host=os.getenv(f"{prefix}HOST", "localhost"),
+            port=int(os.getenv(f"{prefix}PORT", "6379")),
+            password=os.getenv(f"{prefix}PASSWORD"),
+            db=int(os.getenv(f"{prefix}DB", "0")),
+            prefix=os.getenv(f"{prefix}PREFIX", "ar:cache:"),
+            socket_connect_timeout=int(os.getenv(f"{prefix}SOCKET_CONNECT_TIMEOUT", "5")),
+        )
+
+
+class RedisCache:
+    """Distributed cache backend backed by Redis.
+
+    Two construction paths:
+
+    1. Provide an existing ``redis.Redis`` client::
+
+           import redis
+           client = redis.Redis(host="localhost", port=6379, password="secret")
+           cache = RedisCache(client=client)
+
+    2. Provide a :class:`RedisConfig` — the client is created internally::
+
+           config = RedisConfig(host="redis.example.com", port=6379)
+           cache = RedisCache(config=config)
+
+    Args:
+        client: A ``redis.Redis`` (or compatible) instance.
+        config: A :class:`RedisConfig` instance.
+        prefix: Key prefix (overrides ``config.prefix`` when provided).
+        serializer: Serializer for cache values.
+        record_origin: Whether to embed origin metadata (default False).
+        origin_name: Override for origin hostname (default: ``socket.gethostname()``).
+    """
+
+    def __init__(
+        self,
+        client: Any = None,
+        config: Optional[RedisConfig] = None,
+        prefix: Optional[str] = None,
+        serializer: Optional[CacheSerializer] = None,
+        record_origin: bool = False,
+        origin_name: Optional[str] = None,
+    ):
+        if client is not None:
+            self._client = client
+        elif config is not None:
+            import redis as _redis
+            self._client = _redis.Redis(
+                host=config.host,
+                port=config.port,
+                password=config.password or None,
+                db=config.db,
+                socket_connect_timeout=config.socket_connect_timeout,
+            )
+        else:
+            raise TypeError("Either client= or config= must be provided to RedisCache")
+
+        self._prefix = prefix or (config.prefix if config else "ar:cache:")
+        self._serializer = serializer or CacheSerializer()
+        self._record_origin = record_origin
+        self._origin_name = origin_name or socket.gethostname()
+        self._origin = self._origin_name if self._record_origin else None
+
+    @property
+    def origin(self) -> Optional[str]:
+        return self._origin
+
+    def _make_key(self, instance: Any, relation_name: str) -> str:
+        cls = type(instance)
+        pk_val = getattr(instance, instance.primary_key(), None)
+        if pk_val is None:
+            raise ValueError(
+                f"Cannot build cache key for {cls.__name__}.{relation_name}: "
+                f"instance has no primary key value"
+            )
+        return f"{self._prefix}{cls.__name__}:{pk_val}:{relation_name}"
+
+    def get(self, instance: Any, relation_name: str, config: "CacheConfig"):
+        if not config.enabled:
+            return None
+        key = self._make_key(instance, relation_name)
+        payload = self._client.get(key)
+        if payload is None:
+            return None
+        if self._record_origin:
+            meta = json.loads(payload)
+            ttl_remaining = max(0, meta["t"] + (config.ttl or 0) - time.time())
+            logger.debug(
+                "Cache HIT for %s, origin=%s, age=%.1fs, ttl_remaining=%.1f",
+                key, meta["o"], time.time() - meta["t"], ttl_remaining,
+            )
+            return self._serializer.deserialize(base64.b64decode(meta["v"]))
+        return self._serializer.deserialize(payload)
+
+    def get_with_meta(
+        self, instance: Any, relation_name: str, config: "CacheConfig"
+    ) -> Optional["CacheResult"]:
+        from ._protocol import CacheResult
+
+        if not config.enabled:
+            return None
+        key = self._make_key(instance, relation_name)
+        payload = self._client.get(key)
+        if payload is None:
+            return None
+        if self._record_origin:
+            meta = json.loads(payload)
+            now = time.time()
+            age = now - meta["t"]
+            ttl_remaining = max(0, (config.ttl or 0) - age)
+            value = self._serializer.deserialize(base64.b64decode(meta["v"]))
+            logger.debug(
+                "Cache HIT for %s, origin=%s, age=%.1fs, ttl_remaining=%.1f",
+                key, meta["o"], age, ttl_remaining,
+            )
+            return CacheResult(
+                value=value,
+                age=age,
+                origin=meta["o"],
+                ttl=config.ttl,
+            )
+        return CacheResult(
+            value=self._serializer.deserialize(payload),
+            age=0.0,
+            origin=None,
+            ttl=config.ttl,
+        )
+
+    def set(self, instance: Any, relation_name: str, value: Any, config: "CacheConfig"):
+        if not config.enabled:
+            return
+        key = self._make_key(instance, relation_name)
+        data = self._serializer.serialize(value)
+        if self._record_origin:
+            payload = json.dumps({
+                "v": base64.b64encode(data).decode(),
+                "o": self._origin,
+                "t": time.time(),
+            })
+        else:
+            payload = data
+        if config.ttl is not None:
+            self._client.set(key, payload, ex=config.ttl)
+        else:
+            self._client.set(key, payload)
+
+    def delete(self, instance: Any, relation_name: str, config: "CacheConfig" = None):
+        if config is not None and not config.enabled:
+            return
+        key = self._make_key(instance, relation_name)
+        self._client.delete(key)
+
+    def invalidate_instance(self, instance: Any):
+        """Delete all cached relations for an instance."""
+        pattern = f"{self._prefix}{type(instance).__name__}:{getattr(instance, instance.primary_key(), '*')}:*"
+        self._delete_pattern(pattern)
+
+    def _delete_pattern(self, pattern: str):
+        cursor = 0
+        while True:
+            cursor, keys = self._client.scan(cursor, match=pattern, count=100)
+            if keys:
+                self._client.delete(*keys)
+            if cursor == 0:
+                break

--- a/src/rhosocial/activerecord/relation/descriptors.py
+++ b/src/rhosocial/activerecord/relation/descriptors.py
@@ -368,10 +368,9 @@ class RelationDescriptor(Generic[T]):
 
         .. note::
 
-           Cache stampede & proactive refresh are intentionally absent from this
-           layer.  The framework provides ``InstanceCache.get_with_meta()`` and
-           ``.set()`` as building blocks.  Application code (timed tasks, middleware,
-           etc.) can use them to implement its own refresh strategy.
+           External cache metadata and proactive refresh are not introduced in
+           this release.  This layer only performs simple cache read/write via
+           ``InstanceCache.get()`` and ``InstanceCache.set()``.
 
         Args:
             instance: The model instance for which to load the related data

--- a/src/rhosocial/activerecord/relation/descriptors.py
+++ b/src/rhosocial/activerecord/relation/descriptors.py
@@ -390,11 +390,15 @@ class RelationDescriptor(Generic[T]):
         try:
             self.log(logging.DEBUG, f"Loading relation `{self.name}` for {type(instance).__name__}")
             data = self._loader.load(instance) if self._loader else None
-            InstanceCache.set(instance, self.name, data, self._cache_config)
-            return data
         except Exception as e:
             self.log(logging.ERROR, f"Error loading relation: {e}")
             return None
+
+        try:
+            InstanceCache.set(instance, self.name, data, self._cache_config)
+        except Exception as e:
+            self.log(logging.ERROR, f"Error caching relation: {e}")
+        return data
 
     def batch_load(self, records: List[Any], base_query: Optional[IActiveQuery]) -> Dict[int, Any]:
         """

--- a/src/rhosocial/activerecord/relation/descriptors.py
+++ b/src/rhosocial/activerecord/relation/descriptors.py
@@ -381,6 +381,13 @@ class RelationDescriptor(Generic[T]):
         to fetch the data from the database. The loaded data is then cached for future
         access.
 
+        .. note::
+
+           Cache stampede & proactive refresh are intentionally absent from this
+           layer.  The framework provides ``InstanceCache.get_with_meta()`` and
+           ``.set()`` as building blocks.  Application code (timed tasks, middleware,
+           etc.) can use them to implement its own refresh strategy.
+
         Args:
             instance: The model instance for which to load the related data
 

--- a/src/rhosocial/activerecord/relation/descriptors.py
+++ b/src/rhosocial/activerecord/relation/descriptors.py
@@ -29,12 +29,15 @@ def _evaluate_forward_ref(ref: Union[str, ForwardRef], owner: Type[Any]) -> Type
     import sys
     import inspect
 
-    # Get calling frame to access local scope
+    # Get calling frame to access local scope.
+    # Must match frame that actually contains ``owner`` in its locals,
+    # not just any frame from the same module (avoid stale test frames).
     frame = inspect.currentframe()
     while frame:
         if owner.__module__ in str(frame.f_code):
             local_context = frame.f_locals
-            break
+            if owner in local_context.values():
+                break
         frame = frame.f_back
     else:
         local_context = {}
@@ -50,24 +53,6 @@ def _evaluate_forward_ref(ref: Union[str, ForwardRef], owner: Type[Any]) -> Type
     context.update(owner_locals)
 
     type_str = ref if isinstance(ref, str) else ref.__forward_arg__
-
-    if isinstance(ref, ForwardRef):
-        # Use official typing_extensions.evaluate_forward_ref if available
-        try:
-            from typing_extensions import evaluate_forward_ref
-
-            return evaluate_forward_ref(ref, owner=owner, globals=context, locals=None)
-        except ImportError:
-            # Fallback: try using get_type_hints instead of direct _evaluate call
-            try:
-                # Create a temporary class with the forward ref to leverage get_type_hints
-                temp_annotations = {"temp": ref}
-                hints = get_type_hints(type("TempClass", (), {"__annotations__": temp_annotations}), globalns=context)
-                return hints.get("temp", ref)
-            except (NameError, AttributeError, TypeError):
-                pass
-
-    # Final fallback: direct evaluation for string references
     return eval(type_str, context, None)
 
 

--- a/src/rhosocial/activerecord/relation/descriptors.py
+++ b/src/rhosocial/activerecord/relation/descriptors.py
@@ -322,12 +322,10 @@ class RelationDescriptor(Generic[T]):
         """
         self.log(logging.DEBUG, f"Creating relation method for `{self.name}`")
 
-        def relation_method(*args, **kwargs):
-            if args or kwargs:
-                return self._query.query(instance, *args, **kwargs) if self._query else None
+        def relation_method():
             return self._load_relation(instance)
 
-        relation_method.clear_cache = lambda: self._cache.delete(instance)
+        relation_method.clear_cache = lambda: InstanceCache.delete(instance, self.name)
         return relation_method
 
     def _create_query_method(self):
@@ -422,6 +420,8 @@ class RelationDescriptor(Generic[T]):
         Returns:
             Dict mapping record IDs (using id() function) to their related data
         """
+        if not records:
+            return {}
         self.log(logging.DEBUG, f"Batch loading `{self.name}` relation for {len(records)} records")
         if self._cached_model is None:
             self.get_related_model(type(records[0]))

--- a/src/rhosocial/activerecord/relation/descriptors.py
+++ b/src/rhosocial/activerecord/relation/descriptors.py
@@ -172,7 +172,14 @@ class RelationDescriptor(Generic[T]):
         """
         self.name = name
         self._owner = owner
-        # self._cache.relation_name = name
+
+        from ..interface import IAsyncActiveRecord
+        if issubclass(owner, IAsyncActiveRecord):
+            raise TypeError(
+                f"Sync relation descriptor `{name}` cannot be used on async model `{owner.__name__}`. "
+                f"Use AsyncBelongsTo/AsyncHasMany/AsyncHasOne from "
+                f"rhosocial.activerecord.relation.async_descriptors instead."
+            )
 
         self.log(logging.DEBUG, f"Registering relation `{name}` with `{owner.__name__}`")
         owner.register_relation(name, self)

--- a/tests/benchmark/relation/conftest.py
+++ b/tests/benchmark/relation/conftest.py
@@ -1,0 +1,149 @@
+"""Benchmark fixtures for relation cache comparison.
+
+Bridges ``user_post_comment_classes`` from the testsuite's relation conftest
+so that benchmarks can reuse the same model definitions and backend setup.
+
+Redis connection is configured via ``tests/providers/redis_scenarios.yaml``
+using the ``"benchmark"`` scenario.  Users can edit that file to point to
+their own Redis instance.
+"""
+
+from rhosocial.activerecord.testsuite.feature.relation.conftest import (  # noqa: F401
+    user_post_comment_classes,
+)
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from rhosocial.activerecord.relation.cache import CacheConfig, InstanceCache
+from rhosocial.activerecord.relation.cache_backends import (
+    InMemoryCache,
+    RedisCache,
+)
+
+pytestmark = [
+    pytest.mark.benchmark,
+    pytest.mark.benchmark_relation,
+]
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "benchmark_relation: relation cache benchmark tests")
+
+
+@dataclass
+class RelationBenchmarkContext:
+    """Context for a single benchmark run."""
+    user: Any
+    post_class: Any
+    scenario: str
+
+
+# ---------------------------------------------------------------------------
+# Per-session Redis client, loaded from YAML scenario file
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+def _redis_client():
+    from providers.redis_scenarios import get_redis_scenario
+
+    config = get_redis_scenario("benchmark")
+    redis = pytest.importorskip("redis")
+    try:
+        client = redis.Redis(
+            host=config.host,
+            port=config.port,
+            password=config.password or None,
+            db=config.db,
+            socket_connect_timeout=config.socket_connect_timeout,
+        )
+        client.ping()
+        yield client
+        client.flushdb()
+        client.close()
+    except Exception:
+        pytest.skip("Redis not available for benchmark")
+        yield None
+
+
+# ---------------------------------------------------------------------------
+# Shared model + data setup (function-scoped so each test gets fresh data)
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="function")
+def _raw_models(user_post_comment_classes):
+    """Create a user + 100 posts + 200 comments under the same user."""
+    user_cls, post_cls, comment_cls = user_post_comment_classes
+    user = user_cls(name="Bench User", email="bench@example.com")
+    user.save()
+
+    for i in range(100):
+        p = post_cls(title=f"Post {i}", body=f"Body {i}", user_id=user.id)
+        p.save()
+
+    yield user, post_cls, comment_cls
+
+    for p in reversed(post_cls.find_all()):
+        p.delete()
+    user.delete()
+
+
+# ---------------------------------------------------------------------------
+# Cache scenario parametrization
+# ---------------------------------------------------------------------------
+CACHE_SCENARIOS = [
+    pytest.param("no_cache", id="no_cache"),
+    pytest.param("in_memory", id="in_memory"),
+    pytest.param("redis", id="redis"),
+]
+
+
+@pytest.fixture(params=CACHE_SCENARIOS)
+def cache_scenario(request):
+    """Parametrized cache scenario name."""
+    return request.param
+
+
+@pytest.fixture(scope="function")
+def relation_benchmark_env(cache_scenario, _raw_models, _redis_client):
+    """Configure the InstanceCache backend and return a benchmark context.
+
+    Each test function receives a ``RelationBenchmarkContext`` with:
+    - user — the seeded user instance
+    - post_class — for queries
+    - scenario — current scenario name
+    """
+    user, post_cls, comment_cls = _raw_models
+    original_backend = InstanceCache._backend
+
+    try:
+        if cache_scenario == "no_cache":
+            InstanceCache.set_backend(InMemoryCache())
+            config = CacheConfig(enabled=False)
+        elif cache_scenario == "in_memory":
+            InstanceCache.set_backend(InMemoryCache())
+            config = CacheConfig(enabled=True, ttl=None)
+        elif cache_scenario == "redis":
+            InstanceCache.set_backend(
+                RedisCache(
+                    client=_redis_client,
+                    prefix="bench:cache:",
+                )
+            )
+            config = CacheConfig(enabled=True, ttl=None)
+        else:
+            raise ValueError(f"Unknown scenario: {cache_scenario}")
+
+        # Apply the cache config to all relation descriptors
+        for rel_name in ["posts", "comments"]:
+            rel = user.get_relation(rel_name)
+            if rel is not None:
+                rel._cache_config = config
+
+        yield RelationBenchmarkContext(
+            user=user,
+            post_class=post_cls,
+            scenario=cache_scenario,
+        )
+    finally:
+        InstanceCache.set_backend(original_backend)

--- a/tests/benchmark/relation/conftest.py
+++ b/tests/benchmark/relation/conftest.py
@@ -3,9 +3,8 @@
 Bridges ``user_post_comment_classes`` from the testsuite's relation conftest
 so that benchmarks can reuse the same model definitions and backend setup.
 
-Redis connection is configured via ``tests/providers/redis_scenarios.yaml``
-using the ``"benchmark"`` scenario.  Users can edit that file to point to
-their own Redis instance.
+Redis benchmark support is not introduced in this release.  The related
+source snippets are kept as comments for follow-up external cache design.
 """
 
 from rhosocial.activerecord.testsuite.feature.relation.conftest import (  # noqa: F401
@@ -18,11 +17,10 @@ from typing import Any
 import pytest
 
 from rhosocial.activerecord.relation.cache import CacheConfig, InstanceCache
-from rhosocial.activerecord.relation.cache_backends import (
-    CacheSerializer,
-    InMemoryCache,
-    RedisCache,
-)
+from rhosocial.activerecord.relation.cache_backends import InMemoryCache
+
+# Not introduced in this release; keep snippets for follow-up external cache design.
+# from rhosocial.activerecord.relation.cache_backends import CacheSerializer, RedisCache
 
 pytestmark = [
     pytest.mark.benchmark,
@@ -43,35 +41,35 @@ class RelationBenchmarkContext:
 
 
 # ---------------------------------------------------------------------------
-# Per-session Redis client — loaded from YAML or env var fallback
+# Redis benchmark is not introduced in this release.  Keep the fixture shape as
+# comments for follow-up external cache design instead of deleting the source.
 # ---------------------------------------------------------------------------
-@pytest.fixture(scope="session")
-def _redis_client():
-    redis = pytest.importorskip("redis")
-    try:
-        from providers.redis_scenarios import get_redis_scenario
-
-        config = get_redis_scenario("benchmark")
-    except (FileNotFoundError, KeyError):
-        # No YAML file or no "benchmark" entry — fall back to env vars
-        from rhosocial.activerecord.relation.cache_backends import RedisConfig
-
-        config = RedisConfig.from_env()
-    try:
-        client = redis.Redis(
-            host=config.host,
-            port=config.port,
-            password=config.password or None,
-            db=config.db,
-            socket_connect_timeout=config.socket_connect_timeout,
-        )
-        client.ping()
-        yield client
-        client.flushdb()
-        client.close()
-    except Exception:
-        pytest.skip("Redis not available for benchmark")
-        yield None
+# @pytest.fixture(scope="session")
+# def _redis_client():
+#     redis = pytest.importorskip("redis")
+#     try:
+#         from providers.redis_scenarios import get_redis_scenario
+#
+#         config = get_redis_scenario("benchmark")
+#     except (FileNotFoundError, KeyError):
+#         from rhosocial.activerecord.relation.cache_backends import RedisConfig
+#
+#         config = RedisConfig.from_env()
+#     try:
+#         client = redis.Redis(
+#             host=config.host,
+#             port=config.port,
+#             password=config.password or None,
+#             db=config.db,
+#             socket_connect_timeout=config.socket_connect_timeout,
+#         )
+#         client.ping()
+#         yield client
+#         client.flushdb()
+#         client.close()
+#     except Exception:
+#         pytest.skip("Redis not available for benchmark")
+#         yield None
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +99,8 @@ def _raw_models(user_post_comment_classes):
 CACHE_SCENARIOS = [
     pytest.param("no_cache", id="no_cache"),
     pytest.param("in_memory", id="in_memory"),
-    pytest.param("redis", id="redis"),
+    # Not introduced in this release; keep for follow-up external cache design.
+    # pytest.param("redis", id="redis"),
 ]
 
 
@@ -112,7 +111,7 @@ def cache_scenario(request):
 
 
 @pytest.fixture(scope="function")
-def relation_benchmark_env(cache_scenario, _raw_models, _redis_client):
+def relation_benchmark_env(cache_scenario, _raw_models):
     """Configure the InstanceCache backend and return a benchmark context.
 
     Each test function receives a ``RelationBenchmarkContext`` with:
@@ -130,15 +129,16 @@ def relation_benchmark_env(cache_scenario, _raw_models, _redis_client):
         elif cache_scenario == "in_memory":
             InstanceCache.set_backend(InMemoryCache())
             config = CacheConfig(enabled=True, ttl=None)
-        elif cache_scenario == "redis":
-            InstanceCache.set_backend(
-                RedisCache(
-                    client=_redis_client,
-                    prefix="bench:cache:",
-                    serializer=CacheSerializer(format="pickle"),
-                )
-            )
-            config = CacheConfig(enabled=True, ttl=None)
+        # Not introduced in this release; keep for follow-up external cache design.
+        # elif cache_scenario == "redis":
+        #     InstanceCache.set_backend(
+        #         RedisCache(
+        #             client=_redis_client,
+        #             prefix="bench:cache:",
+        #             serializer=CacheSerializer(format="pickle"),
+        #         )
+        #     )
+        #     config = CacheConfig(enabled=True, ttl=None)
         else:
             raise ValueError(f"Unknown scenario: {cache_scenario}")
 

--- a/tests/benchmark/relation/conftest.py
+++ b/tests/benchmark/relation/conftest.py
@@ -42,14 +42,20 @@ class RelationBenchmarkContext:
 
 
 # ---------------------------------------------------------------------------
-# Per-session Redis client, loaded from YAML scenario file
+# Per-session Redis client — loaded from YAML or env var fallback
 # ---------------------------------------------------------------------------
 @pytest.fixture(scope="session")
 def _redis_client():
-    from providers.redis_scenarios import get_redis_scenario
-
-    config = get_redis_scenario("benchmark")
     redis = pytest.importorskip("redis")
+    try:
+        from providers.redis_scenarios import get_redis_scenario
+
+        config = get_redis_scenario("benchmark")
+    except (FileNotFoundError, KeyError):
+        # No YAML file or no "benchmark" entry — fall back to env vars
+        from rhosocial.activerecord.relation.cache_backends import RedisConfig
+
+        config = RedisConfig.from_env()
     try:
         client = redis.Redis(
             host=config.host,

--- a/tests/benchmark/relation/conftest.py
+++ b/tests/benchmark/relation/conftest.py
@@ -19,6 +19,7 @@ import pytest
 
 from rhosocial.activerecord.relation.cache import CacheConfig, InstanceCache
 from rhosocial.activerecord.relation.cache_backends import (
+    CacheSerializer,
     InMemoryCache,
     RedisCache,
 )
@@ -134,6 +135,7 @@ def relation_benchmark_env(cache_scenario, _raw_models, _redis_client):
                 RedisCache(
                     client=_redis_client,
                     prefix="bench:cache:",
+                    serializer=CacheSerializer(format="pickle"),
                 )
             )
             config = CacheConfig(enabled=True, ttl=None)

--- a/tests/benchmark/relation/test_cache_comparison.py
+++ b/tests/benchmark/relation/test_cache_comparison.py
@@ -1,0 +1,74 @@
+"""Benchmark comparing relation cache strategies.
+
+Measures HasMany relation access time under three scenarios:
+- ``no_cache``  — CacheConfig(enabled=False), always queries DB
+- ``in_memory`` — InMemoryCache, caches after first access
+- ``redis``     — RedisCache, caches after first access
+"""
+
+import pytest
+
+pytestmark = [
+    pytest.mark.benchmark,
+    pytest.mark.benchmark_relation,
+]
+
+
+class TestRelationFirstAccess:
+    """First access — always queries DB regardless of cache strategy."""
+
+    def test_posts_first_access(self, benchmark, relation_benchmark_env):
+        ctx = relation_benchmark_env
+        result = benchmark(ctx.user.posts)
+        assert len(result) == 100
+
+
+class TestRelationCachedAccess:
+    """Second+ access — cache hit (except no_cache which hits DB each time)."""
+
+    def test_posts_second_access(self, benchmark, relation_benchmark_env):
+        ctx = relation_benchmark_env
+        ctx.user.posts()
+        result = benchmark(ctx.user.posts)
+        assert len(result) == 100
+
+
+class TestRelationRepeatedAccess:
+    """100 repeated accesses — amplifies cache vs no-cache gap."""
+
+    def test_posts_repeated_access(self, benchmark, relation_benchmark_env):
+        ctx = relation_benchmark_env
+
+        def repeated():
+            for _ in range(100):
+                ctx.user.posts()
+
+        benchmark(repeated)
+
+
+class TestRelationWithNewData:
+    """Access with new data — validates behaviour after mutations."""
+
+    def test_posts_after_new_record(self, benchmark, relation_benchmark_env):
+        """After a new record is added, cached backends return stale data.
+
+        This is expected — cache invalidation is handled by model save/delete
+        events, not by the descriptor layer itself.
+        """
+        ctx = relation_benchmark_env
+        ctx.user.posts()
+        ctx.post_class(title="New", body="New", user_id=ctx.user.id).save()
+        result = benchmark(ctx.user.posts)
+        if ctx.scenario == "no_cache":
+            assert len(result) == 101
+        else:
+            assert len(result) == 100  # stale cache
+
+    def test_posts_after_delete(self, benchmark, relation_benchmark_env):
+        ctx = relation_benchmark_env
+        ctx.user.posts()
+        p = ctx.post_class(title="Temp", body="Temp", user_id=ctx.user.id)
+        p.save()
+        p.delete()
+        result = benchmark(ctx.user.posts)
+        assert len(result) == 100

--- a/tests/benchmark/relation/test_cache_comparison.py
+++ b/tests/benchmark/relation/test_cache_comparison.py
@@ -1,9 +1,10 @@
 """Benchmark comparing relation cache strategies.
 
-Measures HasMany relation access time under three scenarios:
+Measures HasMany relation access time under current-release scenarios:
 - ``no_cache``  — CacheConfig(enabled=False), always queries DB
 - ``in_memory`` — InMemoryCache, caches after first access
-- ``redis``     — RedisCache, caches after first access
+
+Redis benchmark support is not introduced in this release.
 """
 
 import pytest

--- a/tests/providers/redis_scenarios.py
+++ b/tests/providers/redis_scenarios.py
@@ -1,0 +1,128 @@
+# tests/providers/redis_scenarios.py
+"""Redis cache scenario loader from YAML configuration.
+
+Provides a clean, file-based approach to configure Redis connections
+for testing and benchmarking.  Users can add their own scenarios
+to ``redis_scenarios.yaml`` or create a separate YAML file following
+the same format.
+
+Usage::
+
+    from providers.redis_scenarios import get_redis_scenario
+
+    # Get a pre-defined scenario
+    config = get_redis_scenario("default")
+
+    # List all available scenarios
+    scenarios = get_enabled_redis_scenarios()
+
+The returned *config* is a :class:`RedisConfig` instance that can be
+passed directly to ``RedisCache(config=...)`` or used to create a
+raw ``redis.Redis`` client.
+"""
+
+import os
+import re
+from typing import Dict, Optional, get_type_hints
+
+import yaml
+
+from rhosocial.activerecord.relation.cache_backends import RedisConfig
+
+_FILE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config", "redis_scenarios.yaml")
+
+# Cache for loaded scenarios (module-level singleton)
+_SCENARIOS: Dict[str, dict] = {}
+
+
+def _interpolate_env(value) -> str:
+    """Replace ``${VAR_NAME}`` / ``${VAR_NAME:-default}`` with env var values."""
+    if not isinstance(value, str):
+        return value
+
+    def _replace(match):
+        var_name = match.group(1)
+        default = match.group(2)
+        return os.environ.get(var_name, default or "")
+
+    return re.sub(r"\$\{(\w+)(?::-([^}]*))?\}", _replace, value)
+
+
+def _load_scenarios() -> Dict[str, dict]:
+    """Load and interpolate all scenarios from the YAML file.
+
+    Returns empty dict when the file does not exist (it is optional and
+    lives in ``tests/config/``, which is git-excluded).
+    """
+    if not os.path.exists(_FILE_PATH):
+        return {}
+
+    with open(_FILE_PATH, "r") as f:
+        raw = yaml.safe_load(f)
+
+    if not raw:
+        return {}
+
+    return {
+        name: {k: _interpolate_env(v) for k, v in conf.items()}
+        for name, conf in raw.items()
+    }
+
+
+def register_redis_scenario(name: str, config: dict):
+    """Register (or override) a Redis scenario at runtime."""
+    _SCENARIOS[name] = {k: _interpolate_env(v) for k, v in config.items()}
+
+
+def _to_int(value) -> int:
+    """Convert a value to int, handling strings from YAML/env."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip():
+        return int(value)
+    return 0
+
+
+def get_redis_scenario(name: str) -> "RedisConfig":
+    """Return a :class:`RedisConfig` for the named scenario.
+
+    Falls back to ``"default"`` if *name* is not found.
+    String values that should be integers (port, db, socket_connect_timeout)
+    are automatically converted.
+    """
+    if not _SCENARIOS:
+        _SCENARIOS.update(_load_scenarios())
+
+    if not _SCENARIOS:
+        raise FileNotFoundError(
+            f"No Redis scenarios loaded. Create {_FILE_PATH} with a "
+            f"'default' entry, or call register_redis_scenario() first."
+        )
+    raw = _SCENARIOS.get(name)
+    if raw is None:
+        raw = _SCENARIOS.get("default")
+    if raw is None:
+        raise KeyError(f"No Redis scenario named '{name}' and no 'default' scenario found")
+
+    # Strip None-valued keys so RedisConfig defaults apply, convert types
+    cleaned = {}
+    for k, v in raw.items():
+        if v is None:
+            continue
+        # Convert known integer fields (handles string values from YAML/env)
+        if k in ("port", "db", "socket_connect_timeout"):
+            v = _to_int(v)
+        cleaned[k] = v
+
+    return RedisConfig(**cleaned)
+
+
+def get_enabled_redis_scenarios() -> Dict[str, dict]:
+    """Return the raw dict of all loaded scenario names → config dicts."""
+    if not _SCENARIOS:
+        _SCENARIOS.update(_load_scenarios())
+    return dict(_SCENARIOS)
+
+
+# Load scenarios at import time (one-time cost)
+_SCENARIOS.update(_load_scenarios())

--- a/tests/providers/registry.py
+++ b/tests/providers/registry.py
@@ -32,6 +32,7 @@ from .query import QueryProvider
 from .basic_connection import BasicConnectionProvider
 from .query_connection import QueryConnectionProvider
 from .derived_field import DerivedFieldProvider
+from .relation import RelationProvider
 from .crud_benchmark import CrudBenchmarkProvider
 from .fastapi_benchmark import FastAPIBenchmarkProvider
 from .mixin_benchmark import MixinBenchmarkProvider
@@ -68,6 +69,8 @@ provider_registry.register("feature.basic.connection.IBasicConnectionProvider", 
 provider_registry.register("feature.query.connection.IQueryConnectionProvider", QueryConnectionProvider)
 
 provider_registry.register("feature.derived_field.IDerivedFieldProvider", DerivedFieldProvider)
+
+provider_registry.register("feature.relation.IRelationProvider", RelationProvider)
 
 # Register benchmark providers.
 provider_registry.register("benchmark.crud.ICrudBenchmarkProvider", CrudBenchmarkProvider)

--- a/tests/providers/relation.py
+++ b/tests/providers/relation.py
@@ -1,6 +1,6 @@
 # tests/providers/relation.py
 import asyncio
-from typing import Type, List, Tuple
+from typing import Dict, List, Tuple, Type
 
 from rhosocial.activerecord.model import ActiveRecord, AsyncActiveRecord
 from rhosocial.activerecord.backend.impl.sqlite.backend.async_backend import AsyncSQLiteBackend
@@ -9,6 +9,8 @@ from rhosocial.activerecord.testsuite.feature.relation.fixtures.models import (
     Employee, Department, Author, Book, Chapter, Profile,
     User, Post, Comment,
     AsyncUser, AsyncPost, AsyncComment,
+    BoundaryOwner, BoundaryProfile, BoundaryPost,
+    AsyncBoundaryOwner, AsyncBoundaryProfile, AsyncBoundaryPost,
 )
 from .scenarios import get_enabled_scenarios, get_scenario
 
@@ -86,6 +88,26 @@ USER_POST_COMMENT_SCHEMA = """
     DELETE FROM users;
 """
 
+RELATION_BOUNDARY_SCHEMA = """
+    CREATE TABLE IF NOT EXISTS relation_boundary_owners (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS relation_boundary_profiles (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        bio TEXT NOT NULL,
+        owner_id INTEGER
+    );
+    CREATE TABLE IF NOT EXISTS relation_boundary_posts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        owner_id INTEGER
+    );
+    DELETE FROM relation_boundary_posts;
+    DELETE FROM relation_boundary_profiles;
+    DELETE FROM relation_boundary_owners;
+"""
+
 
 class RelationProvider(IRelationProvider):
 
@@ -94,6 +116,8 @@ class RelationProvider(IRelationProvider):
         self._active_async_backends = []
         self._sync_user_post_comment_setup = False
         self._async_user_post_comment_setup = False
+        self._sync_relation_boundary_setup = False
+        self._async_relation_boundary_setup = False
 
     def get_test_scenarios(self) -> List[str]:
         return list(get_enabled_scenarios().keys())
@@ -157,6 +181,40 @@ class RelationProvider(IRelationProvider):
             asyncio.run(_setup())
             self._async_user_post_comment_setup = True
 
+    def _setup_relation_boundary_sync(self, scenario_name):
+        if not self._sync_relation_boundary_setup:
+            backend_class, config = get_scenario(scenario_name)
+            BoundaryOwner.configure(config, backend_class)
+            backend = BoundaryOwner.backend()
+            backend.connect()
+            backend.introspect_and_adapt()
+            self._active_backends.append(backend)
+            backend.executescript(RELATION_BOUNDARY_SCHEMA)
+            BoundaryProfile.configure(config, backend_class)
+            BoundaryPost.configure(config, backend_class)
+            self._sync_relation_boundary_setup = True
+
+    def _setup_relation_boundary_async(self, scenario_name):
+        if not self._async_relation_boundary_setup:
+            _, config = get_scenario(scenario_name)
+
+            async def _setup():
+                await AsyncBoundaryOwner.configure(config, AsyncSQLiteBackend)
+                backend = AsyncBoundaryOwner.backend()
+                await backend.connect()
+                await backend.introspect_and_adapt()
+                self._active_async_backends.append(backend)
+                await backend.executescript(RELATION_BOUNDARY_SCHEMA)
+                AsyncBoundaryProfile.__connection_config__ = config
+                AsyncBoundaryProfile.__backend_class__ = AsyncSQLiteBackend
+                AsyncBoundaryProfile.__backend__ = backend
+                AsyncBoundaryPost.__connection_config__ = config
+                AsyncBoundaryPost.__backend_class__ = AsyncSQLiteBackend
+                AsyncBoundaryPost.__backend__ = backend
+
+            asyncio.run(_setup())
+            self._async_relation_boundary_setup = True
+
     def setup_employee_department_fixtures(self, scenario_name: str) -> Tuple[Type[ActiveRecord], Type[ActiveRecord]]:
         return self._setup_employee_department(scenario_name)
 
@@ -187,6 +245,101 @@ class RelationProvider(IRelationProvider):
         self._setup_user_post_comment_async(scenario_name)
         return AsyncComment
 
+    def setup_relation_boundary_fixtures(
+        self,
+        scenario_name: str,
+    ) -> Tuple[Type[ActiveRecord], Type[ActiveRecord], Type[ActiveRecord]]:
+        self._setup_relation_boundary_sync(scenario_name)
+        return BoundaryOwner, BoundaryProfile, BoundaryPost
+
+    def setup_async_relation_boundary_fixtures(
+        self,
+        scenario_name: str,
+    ) -> Tuple[Type[AsyncActiveRecord], Type[AsyncActiveRecord], Type[AsyncActiveRecord]]:
+        self._setup_relation_boundary_async(scenario_name)
+        return AsyncBoundaryOwner, AsyncBoundaryProfile, AsyncBoundaryPost
+
+    def load_relation_boundary_dataset(self, scenario_name: str, dataset_name: str) -> Dict[str, int]:
+        self._setup_relation_boundary_sync(scenario_name)
+        return self._load_relation_boundary_dataset(
+            BoundaryOwner,
+            BoundaryProfile,
+            BoundaryPost,
+            dataset_name,
+        )
+
+    async def load_async_relation_boundary_dataset(
+        self,
+        scenario_name: str,
+        dataset_name: str,
+    ) -> Dict[str, int]:
+        self._setup_relation_boundary_async(scenario_name)
+        return await self._load_async_relation_boundary_dataset(dataset_name)
+
+    def _load_relation_boundary_dataset(self, owner_class, profile_class, post_class, dataset_name):
+        if dataset_name == "null_foreign_key":
+            profile = profile_class(bio="No owner", owner_id=None)
+            profile.save()
+            return {"profile_id": profile.id}
+
+        if dataset_name == "orphan_foreign_key":
+            missing_owner_id = 999999
+            post = post_class(title="Orphan post", owner_id=missing_owner_id)
+            post.save()
+            return {"post_id": post.id, "missing_owner_id": missing_owner_id}
+
+        if dataset_name == "owner_without_children":
+            owner = owner_class(name="Owner without children")
+            owner.save()
+            return {"owner_id": owner.id}
+
+        if dataset_name == "multiple_has_one_matches":
+            owner = owner_class(name="Owner with duplicate profiles")
+            owner.save()
+            first = profile_class(bio="First profile", owner_id=owner.id)
+            first.save()
+            second = profile_class(bio="Second profile", owner_id=owner.id)
+            second.save()
+            return {
+                "owner_id": owner.id,
+                "first_profile_id": first.id,
+                "second_profile_id": second.id,
+            }
+
+        raise ValueError(f"Unknown relation boundary dataset: {dataset_name}")
+
+    async def _load_async_relation_boundary_dataset(self, dataset_name):
+        if dataset_name == "null_foreign_key":
+            profile = AsyncBoundaryProfile(bio="No owner", owner_id=None)
+            await profile.save()
+            return {"profile_id": profile.id}
+
+        if dataset_name == "orphan_foreign_key":
+            missing_owner_id = 999999
+            post = AsyncBoundaryPost(title="Orphan post", owner_id=missing_owner_id)
+            await post.save()
+            return {"post_id": post.id, "missing_owner_id": missing_owner_id}
+
+        if dataset_name == "owner_without_children":
+            owner = AsyncBoundaryOwner(name="Owner without children")
+            await owner.save()
+            return {"owner_id": owner.id}
+
+        if dataset_name == "multiple_has_one_matches":
+            owner = AsyncBoundaryOwner(name="Owner with duplicate profiles")
+            await owner.save()
+            first = AsyncBoundaryProfile(bio="First profile", owner_id=owner.id)
+            await first.save()
+            second = AsyncBoundaryProfile(bio="Second profile", owner_id=owner.id)
+            await second.save()
+            return {
+                "owner_id": owner.id,
+                "first_profile_id": first.id,
+                "second_profile_id": second.id,
+            }
+
+        raise ValueError(f"Unknown relation boundary dataset: {dataset_name}")
+
     def cleanup_after_test(self, scenario_name: str) -> None:
         for backend in self._active_backends:
             try:
@@ -202,3 +355,5 @@ class RelationProvider(IRelationProvider):
         self._active_async_backends.clear()
         self._sync_user_post_comment_setup = False
         self._async_user_post_comment_setup = False
+        self._sync_relation_boundary_setup = False
+        self._async_relation_boundary_setup = False

--- a/tests/providers/relation.py
+++ b/tests/providers/relation.py
@@ -1,0 +1,204 @@
+# tests/providers/relation.py
+import asyncio
+from typing import Type, List, Tuple
+
+from rhosocial.activerecord.model import ActiveRecord, AsyncActiveRecord
+from rhosocial.activerecord.backend.impl.sqlite.backend.async_backend import AsyncSQLiteBackend
+from rhosocial.activerecord.testsuite.feature.relation.interfaces import IRelationProvider
+from rhosocial.activerecord.testsuite.feature.relation.fixtures.models import (
+    Employee, Department, Author, Book, Chapter, Profile,
+    User, Post, Comment,
+    AsyncUser, AsyncPost, AsyncComment,
+)
+from .scenarios import get_enabled_scenarios, get_scenario
+
+
+EMPLOYEE_DEPARTMENT_SCHEMA = """
+    CREATE TABLE IF NOT EXISTS employees (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT NOT NULL,
+        department_id INTEGER NOT NULL,
+        FOREIGN KEY (department_id) REFERENCES departments(id)
+    );
+    CREATE TABLE IF NOT EXISTS departments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        description TEXT DEFAULT ''
+    );
+    DELETE FROM employees;
+    DELETE FROM departments;
+"""
+
+AUTHOR_BOOK_SCHEMA = """
+    CREATE TABLE IF NOT EXISTS authors (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS books (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        author_id INTEGER NOT NULL,
+        FOREIGN KEY (author_id) REFERENCES authors(id)
+    );
+    CREATE TABLE IF NOT EXISTS chapters (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        book_id INTEGER NOT NULL,
+        FOREIGN KEY (book_id) REFERENCES books(id)
+    );
+    CREATE TABLE IF NOT EXISTS profiles (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        bio TEXT NOT NULL,
+        author_id INTEGER NOT NULL,
+        FOREIGN KEY (author_id) REFERENCES authors(id)
+    );
+    DELETE FROM chapters;
+    DELETE FROM books;
+    DELETE FROM profiles;
+    DELETE FROM authors;
+"""
+
+USER_POST_COMMENT_SCHEMA = """
+    CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        email TEXT,
+        settings TEXT
+    );
+    CREATE TABLE IF NOT EXISTS posts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        body TEXT NOT NULL,
+        user_id INTEGER NOT NULL,
+        view_count INTEGER NOT NULL DEFAULT 0,
+        metadata TEXT,
+        FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+    CREATE TABLE IF NOT EXISTS comments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        body TEXT NOT NULL,
+        post_id INTEGER NOT NULL,
+        meta TEXT,
+        FOREIGN KEY (post_id) REFERENCES posts(id)
+    );
+    DELETE FROM comments;
+    DELETE FROM posts;
+    DELETE FROM users;
+"""
+
+
+class RelationProvider(IRelationProvider):
+
+    def __init__(self):
+        self._active_backends = []
+        self._active_async_backends = []
+        self._sync_user_post_comment_setup = False
+        self._async_user_post_comment_setup = False
+
+    def get_test_scenarios(self) -> List[str]:
+        return list(get_enabled_scenarios().keys())
+
+    def _setup_employee_department(self, scenario_name):
+        backend_class, config = get_scenario(scenario_name)
+        Employee.configure(config, backend_class)
+        backend = Employee.backend()
+        backend.connect()
+        backend.introspect_and_adapt()
+        self._active_backends.append(backend)
+        backend.executescript(EMPLOYEE_DEPARTMENT_SCHEMA)
+        Department.configure(config, backend_class)
+        return Employee, Department
+
+    def _setup_author_book(self, scenario_name):
+        backend_class, config = get_scenario(scenario_name)
+        Author.configure(config, backend_class)
+        backend = Author.backend()
+        backend.connect()
+        backend.introspect_and_adapt()
+        self._active_backends.append(backend)
+        backend.executescript(AUTHOR_BOOK_SCHEMA)
+        Book.configure(config, backend_class)
+        Chapter.configure(config, backend_class)
+        Profile.configure(config, backend_class)
+        return Author, Book, Chapter, Profile
+
+    def _setup_user_post_comment_sync(self, scenario_name):
+        if not self._sync_user_post_comment_setup:
+            backend_class, config = get_scenario(scenario_name)
+            User.configure(config, backend_class)
+            backend = User.backend()
+            backend.connect()
+            backend.introspect_and_adapt()
+            self._active_backends.append(backend)
+            backend.executescript(USER_POST_COMMENT_SCHEMA)
+            Post.configure(config, backend_class)
+            Comment.configure(config, backend_class)
+            self._sync_user_post_comment_setup = True
+
+    def _setup_user_post_comment_async(self, scenario_name):
+        if not self._async_user_post_comment_setup:
+            _, config = get_scenario(scenario_name)
+
+            async def _setup():
+                await AsyncUser.configure(config, AsyncSQLiteBackend)
+                backend = AsyncUser.backend()
+                await backend.connect()
+                await backend.introspect_and_adapt()
+                self._active_async_backends.append(backend)
+                await backend.executescript(USER_POST_COMMENT_SCHEMA)
+                # Share the same backend instance with AsyncPost and AsyncComment
+                AsyncPost.__connection_config__ = config
+                AsyncPost.__backend_class__ = AsyncSQLiteBackend
+                AsyncPost.__backend__ = backend
+                AsyncComment.__connection_config__ = config
+                AsyncComment.__backend_class__ = AsyncSQLiteBackend
+                AsyncComment.__backend__ = backend
+
+            asyncio.run(_setup())
+            self._async_user_post_comment_setup = True
+
+    def setup_employee_department_fixtures(self, scenario_name: str) -> Tuple[Type[ActiveRecord], Type[ActiveRecord]]:
+        return self._setup_employee_department(scenario_name)
+
+    def setup_author_book_fixtures(self, scenario_name: str) -> Tuple[Type[ActiveRecord], Type[ActiveRecord], Type[ActiveRecord], Type[ActiveRecord]]:
+        return self._setup_author_book(scenario_name)
+
+    def setup_user_model(self, scenario_name: str) -> Type[ActiveRecord]:
+        self._setup_user_post_comment_sync(scenario_name)
+        return User
+
+    def setup_post_model(self, scenario_name: str) -> Type[ActiveRecord]:
+        self._setup_user_post_comment_sync(scenario_name)
+        return Post
+
+    def setup_comment_model(self, scenario_name: str) -> Type[ActiveRecord]:
+        self._setup_user_post_comment_sync(scenario_name)
+        return Comment
+
+    def setup_async_user_model(self, scenario_name: str) -> Type[AsyncActiveRecord]:
+        self._setup_user_post_comment_async(scenario_name)
+        return AsyncUser
+
+    def setup_async_post_model(self, scenario_name: str) -> Type[AsyncActiveRecord]:
+        self._setup_user_post_comment_async(scenario_name)
+        return AsyncPost
+
+    def setup_async_comment_model(self, scenario_name: str) -> Type[AsyncActiveRecord]:
+        self._setup_user_post_comment_async(scenario_name)
+        return AsyncComment
+
+    def cleanup_after_test(self, scenario_name: str) -> None:
+        for backend in self._active_backends:
+            try:
+                backend.disconnect()
+            except Exception:
+                pass
+        self._active_backends.clear()
+        for backend in self._active_async_backends:
+            try:
+                asyncio.run(backend.disconnect())
+            except Exception:
+                pass
+        self._active_async_backends.clear()
+        self._sync_user_post_comment_setup = False
+        self._async_user_post_comment_setup = False

--- a/tests/rhosocial/activerecord_test/feature/relation/test_boundary.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_boundary.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_boundary.py
+"""
+Bridge file for relation boundary tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_boundary import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_boundary_async.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_boundary_async.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_boundary_async.py
+"""
+Bridge file for async relation boundary tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_boundary_async import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_cache_result.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_cache_result.py
@@ -8,6 +8,12 @@ blocks that application code uses to implement its own strategy.
 """
 import pytest
 
+pytest.skip(
+    "CacheResult metadata is not introduced in this release; "
+    "source is kept for follow-up external cache design.",
+    allow_module_level=True,
+)
+
 from pydantic import BaseModel
 
 from rhosocial.activerecord.relation.cache import (

--- a/tests/rhosocial/activerecord_test/feature/relation/test_cache_result.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_cache_result.py
@@ -1,0 +1,106 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_cache_result.py
+"""
+Tests for CacheResult dataclass and InstanceCache.get_with_meta().
+
+Cache stampede protection and proactive refresh are intentionally
+excluded from the framework.  These tests verify the metadata-building
+blocks that application code uses to implement its own strategy.
+"""
+import pytest
+
+from pydantic import BaseModel
+
+from rhosocial.activerecord.relation.cache import (
+    CacheConfig,
+    CacheResult,
+    InstanceCache,
+)
+
+
+class TestCacheResult:
+    """CacheResult dataclass construction and defaults."""
+
+    def test_basic(self):
+        r = CacheResult(value="hello", age=10.0, origin="box-a", ttl=300)
+        assert r.value == "hello"
+        assert r.age == 10.0
+        assert r.origin == "box-a"
+        assert r.ttl == 300
+
+    def test_defaults(self):
+        r = CacheResult(value=42)
+        assert r.age == 0.0
+        assert r.origin is None
+        assert r.ttl is None
+
+    def test_various_types(self):
+        r = CacheResult(value=[1, 2, 3])
+        assert r.value == [1, 2, 3]
+
+        r = CacheResult(value={"key": "val"})
+        assert r.value == {"key": "val"}
+
+        r = CacheResult(value=None)
+        assert r.value is None
+
+
+class TestGetWithMeta:
+    """InstanceCache.get_with_meta() returns CacheResult with metadata."""
+
+    class _Model(BaseModel):
+        id: int
+
+    def test_hit(self):
+        inst = self._Model(id=1)
+        cfg = CacheConfig(ttl=300)
+        InstanceCache.set(inst, "posts", ["p1", "p2"], cfg)
+        r = InstanceCache.get_with_meta(inst, "posts", cfg)
+        assert r is not None
+        assert r.value == ["p1", "p2"]
+        assert r.ttl == 300
+        assert r.origin is None  # InMemoryCache has no origin
+        assert r.age == 0.0
+
+    def test_miss(self):
+        inst = self._Model(id=2)
+        cfg = CacheConfig(ttl=300)
+        r = InstanceCache.get_with_meta(inst, "nonexistent", cfg)
+        assert r is None
+
+    def test_disabled(self):
+        inst = self._Model(id=3)
+        cfg = CacheConfig(enabled=False)
+        InstanceCache.set(inst, "posts", ["p1"], CacheConfig())
+        r = InstanceCache.get_with_meta(inst, "posts", cfg)
+        assert r is None
+
+    def test_ttl_none(self):
+        inst = self._Model(id=4)
+        cfg = CacheConfig(ttl=None)
+        InstanceCache.set(inst, "data", "xyz", cfg)
+        r = InstanceCache.get_with_meta(inst, "data", cfg)
+        assert r is not None
+        assert r.value == "xyz"
+        assert r.ttl is None
+
+    def test_origin_reflects_backend(self):
+        """get_with_meta origin matches the active backend origin."""
+        orig_backend = InstanceCache._backend
+        try:
+            from rhosocial.activerecord.relation.cache_backends import InMemoryCache
+
+            class CustomOrigin(InMemoryCache):
+                @property
+                def origin(self):
+                    return "custom-node"
+
+            InstanceCache.set_backend(CustomOrigin())
+
+            inst = self._Model(id=5)
+            cfg = CacheConfig(ttl=60)
+            InstanceCache.set(inst, "rel", "val", cfg)
+            r = InstanceCache.get_with_meta(inst, "rel", cfg)
+            assert r is not None
+            assert r.origin == "custom-node"
+        finally:
+            InstanceCache.set_backend(orig_backend)

--- a/tests/rhosocial/activerecord_test/feature/relation/test_cache_serialization.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_cache_serialization.py
@@ -16,6 +16,12 @@ from typing import Any, Dict, List, Optional
 
 import pytest
 
+pytest.skip(
+    "Cache serialization is not introduced in this release; "
+    "source is kept for follow-up external cache design.",
+    allow_module_level=True,
+)
+
 from rhosocial.activerecord.relation.cache_backends._protocol import CacheSerializer
 
 # ---------------------------------------------------------------------------

--- a/tests/rhosocial/activerecord_test/feature/relation/test_cache_serialization.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_cache_serialization.py
@@ -1,0 +1,458 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_cache_serialization.py
+"""
+Comprehensive round-trip tests for cache serialization.
+
+Covers JSON (default), msgpack (when available), and pickle (UNSAFE)
+serializers with simple values, complex Python objects, edge cases,
+and large content from the testsuite sample files.
+"""
+
+import json
+import math
+import os
+from datetime import date, datetime, time, timedelta
+from enum import Enum, auto
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from rhosocial.activerecord.relation.cache_backends._protocol import CacheSerializer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE_DIR = None
+
+
+def _find_samples() -> Optional[str]:
+    """Locate the testsuite sample directory."""
+    global _SAMPLE_DIR
+    if _SAMPLE_DIR is not None:
+        return _SAMPLE_DIR
+    try:
+        import rhosocial.activerecord.testsuite as _ts
+        base = os.path.dirname(_ts.__file__)
+        for attempt in [
+            os.path.join(base, "feature", "query", "samples"),
+            os.path.join(base, "..", "..", "..", "..", "testsuite", "feature", "query", "samples"),
+        ]:
+            path = os.path.abspath(attempt)
+            if os.path.isdir(path):
+                _SAMPLE_DIR = path
+                return _SAMPLE_DIR
+    except Exception:
+        pass
+    return None
+
+
+def _load_sample(name: str) -> str:
+    d = _find_samples()
+    if d is None:
+        pytest.skip("testsuite sample directory not found")
+    path = os.path.join(d, name)
+    if not os.path.exists(path):
+        pytest.skip(f"sample file not found: {path}")
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Test data
+# ---------------------------------------------------------------------------
+
+class Color(Enum):
+    RED = auto()
+    GREEN = auto()
+    BLUE = auto()
+
+
+SIMPLE_VALUES: List[Any] = [
+    "hello",
+    "",
+    0,
+    1,
+    -1,
+    3.14,
+    True,
+    False,
+    None,
+    [],
+    {},
+    [1, 2, 3],
+    {"a": 1, "b": 2},
+]
+
+COMPLEX_VALUES: List[Any] = [
+    {"nested": {"deeply": [1, [2, [3]]], "key": "val"}},
+    [{"id": i, "name": f"Item {i}"} for i in range(100)],
+    {"mixed": [1, "two", 3.0, True, None, [1, 2], {"k": "v"}]},
+    {"empty_nested": {"a": {}, "b": [], "c": {"d": {}}}},
+]
+
+EXTENDED_VALUES: List[Any] = [
+    datetime(2026, 6, 2, 14, 30, 0, 123456),
+    date(2026, 6, 2),
+    time(14, 30, 0, 123456),
+    timedelta(days=7, hours=3, minutes=15),
+    Color.RED,
+    bytes([0x00, 0xFF, 0xAB, 0xCD]),
+    {1, 2, 3, 4, 5},
+    complex(3, 4),
+    range(0, 10, 2),
+    {"dt": datetime.now(), "color": Color.BLUE, "data": bytes([1, 2, 3])},
+    [datetime(2026, 1, 1), timedelta(hours=1), Color.GREEN],
+]
+
+FLOAT_EPS = 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Serializer fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(params=["json", "msgpack", "pickle"])
+def serializer(request) -> CacheSerializer:
+    fmt = request.param
+    if fmt == "msgpack":
+        try:
+            import msgpack  # noqa: F401
+        except ImportError:
+            pytest.skip("msgpack not installed")
+            return None
+    return CacheSerializer(format=fmt)
+
+
+@pytest.fixture
+def json_serializer() -> CacheSerializer:
+    return CacheSerializer(format="json")
+
+
+@pytest.fixture
+def pickle_serializer() -> CacheSerializer:
+    return CacheSerializer(format="pickle")
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests
+# ---------------------------------------------------------------------------
+
+class TestCacheSerializerBasic:
+    """Basic values round-trip through all serializer formats."""
+
+    @pytest.mark.parametrize("value", SIMPLE_VALUES)
+    def test_simple(self, serializer, value):
+        data = serializer.serialize(value)
+        restored = serializer.deserialize(data)
+        assert restored == value
+        assert type(restored) is type(value)
+
+    def test_list_of_strings(self, serializer):
+        value = ["a" * 100] * 1000
+        data = serializer.serialize(value)
+        restored = serializer.deserialize(data)
+        assert restored == value
+        assert len(restored) == 1000
+
+
+class TestCacheSerializerComplex:
+    """Complex nested values round-trip."""
+
+    @pytest.mark.parametrize("value", COMPLEX_VALUES)
+    def test_complex(self, serializer, value):
+        data = serializer.serialize(value)
+        restored = serializer.deserialize(data)
+        assert restored == value
+
+    def test_large_dict(self, serializer):
+        value = {f"key_{i}": f"value_{i}" for i in range(5000)}
+        data = serializer.serialize(value)
+        restored = serializer.deserialize(data)
+        assert restored == value
+        assert len(restored) == 5000
+
+
+class TestCacheSerializerExtended:
+    """Extended types (datetime, Enum, bytes, etc.) through JSON (and msgpack)."""
+
+    def _roundtrip_json(self, value):
+        ser = CacheSerializer(format="json")
+        data = ser.serialize(value)
+        return ser.deserialize(data)
+
+    def test_datetime(self):
+        v = datetime(2026, 6, 2, 14, 30, 0, 123456)
+        restored = self._roundtrip_json(v)
+        assert isinstance(restored, dict)
+        assert restored["__type__"] == "datetime"
+        assert restored["value"] == v.isoformat()
+
+    def test_date(self):
+        v = date(2026, 6, 2)
+        restored = self._roundtrip_json(v)
+        assert isinstance(restored, dict)
+        assert restored["__type__"] == "datetime"
+        assert restored["value"] == v.isoformat()
+
+    def test_time(self):
+        v = time(14, 30, 0, 123456)
+        restored = self._roundtrip_json(v)
+        assert isinstance(restored, dict)
+        assert restored["__type__"] == "time"
+        assert restored["value"] == v.isoformat()
+
+    def test_timedelta(self):
+        v = timedelta(days=7, hours=3, minutes=15)
+        restored = self._roundtrip_json(v)
+        assert isinstance(restored, dict)
+        assert restored["__type__"] == "timedelta"
+        assert isinstance(restored["value"], float)
+        assert abs(restored["value"] - v.total_seconds()) < FLOAT_EPS
+
+    def test_enum(self):
+        v = Color.RED
+        restored = self._roundtrip_json(v)
+        assert isinstance(restored, dict)
+        assert restored["__type__"] == "enum"
+        assert restored["value"] == "RED"
+
+    def test_bytes(self):
+        v = bytes([0x00, 0xFF, 0xAB, 0xCD])
+        restored = self._roundtrip_json(v)
+        assert isinstance(restored, dict)
+        assert restored["__type__"] == "bytes"
+        assert bytes.fromhex(restored["value"]) == v
+
+    def test_set(self):
+        v = {1, 2, 3, 4, 5}
+        restored = self._roundtrip_json(v)
+        assert isinstance(restored, dict)
+        assert restored["__type__"] == "set"
+        assert set(restored["value"]) == v
+
+    def test_complex_number(self):
+        v = complex(3, 4)
+        restored = self._roundtrip_json(v)
+        assert isinstance(restored, dict)
+        assert restored["__type__"] == "complex"
+        assert restored["value"] == [3.0, 4.0]
+
+    def test_range(self):
+        v = range(0, 10, 2)
+        restored = self._roundtrip_json(v)
+        assert isinstance(restored, dict)
+        assert restored["__type__"] == "range"
+        assert restored["value"] == [0, 10, 2]
+
+
+class TestCacheSerializerMsgpackExtended:
+    """Extended types through msgpack (native support for bytes, etc.)."""
+
+    @pytest.fixture
+    def msgpack_ser(self):
+        try:
+            import msgpack  # noqa: F401
+        except ImportError:
+            pytest.skip("msgpack not installed")
+        return CacheSerializer(format="msgpack")
+
+    def test_bytes(self, msgpack_ser):
+        v = bytes([0x00, 0xFF, 0xAB])
+        restored = msgpack_ser.deserialize(msgpack_ser.serialize(v))
+        assert restored == v
+
+    def test_datetime(self, msgpack_ser):
+        v = datetime(2026, 6, 2, 14, 30, 0)
+        restored = msgpack_ser.deserialize(msgpack_ser.serialize(v))
+        # msgpack does not preserve datetime natively — it's treated as string
+        assert isinstance(restored, str)
+
+    def test_set(self, msgpack_ser):
+        v = {1, 2, 3}
+        data = msgpack_ser.serialize(v)
+        with pytest.raises(TypeError):
+            msgpack_ser.deserialize(data)
+
+    def test_enum(self, msgpack_ser):
+        v = Color.GREEN
+        data = msgpack_ser.serialize(v)
+        with pytest.raises(TypeError):
+            msgpack_ser.deserialize(data)
+
+
+class TestCacheSerializerLargeContent:
+    """Large content round-trip using testsuite sample files."""
+
+    SAMPLE_FILES = [
+        "jsonplaceholder_posts.json",
+        "python_home.html",
+        "plant_catalog.xml",
+        "unicode_multilingual.html",
+        "unicode_multilingual.json",
+        "unicode_multilingual.xml",
+    ]
+
+    @pytest.mark.parametrize("filename", SAMPLE_FILES)
+    def test_large_content_json(self, json_serializer, filename):
+        content = _load_sample(filename)
+        data = json_serializer.serialize(content)
+        restored = json_serializer.deserialize(data)
+        assert restored == content
+        assert isinstance(restored, str)
+        assert len(restored) == len(content)
+
+    @pytest.mark.parametrize("filename", SAMPLE_FILES)
+    def test_large_content_pickle(self, pickle_serializer, filename):
+        content = _load_sample(filename)
+        data = pickle_serializer.serialize(content)
+        restored = pickle_serializer.deserialize(data)
+        assert restored == content
+
+    def test_json_placeholder_structure(self, json_serializer):
+        """Load a JSON file as dict, serialize and restore via JSON serializer."""
+        content = _load_sample("jsonplaceholder_posts.json")
+        parsed = json.loads(content)
+        data = json_serializer.serialize(parsed)
+        restored = json_serializer.deserialize(data)
+        assert restored == parsed
+        assert len(restored) == len(parsed)
+        assert isinstance(restored, list)
+
+    def test_multilingual_json_structure(self, json_serializer):
+        """Multilingual JSON with Unicode content."""
+        content = _load_sample("unicode_multilingual.json")
+        parsed = json.loads(content)
+        data = json_serializer.serialize(parsed)
+        restored = json_serializer.deserialize(data)
+        assert restored == parsed
+
+
+class TestCacheSerializerEdgeCases:
+    """Edge cases and error handling."""
+
+    def test_empty_string(self, serializer):
+        v = ""
+        data = serializer.serialize(v)
+        assert serializer.deserialize(data) == v
+
+    def test_very_long_string(self, serializer):
+        v = "x" * 100_000
+        data = serializer.serialize(v)
+        restored = serializer.deserialize(data)
+        assert restored == v
+        assert len(restored) == 100_000
+
+    def test_none_value(self, serializer):
+        data = serializer.serialize(None)
+        assert serializer.deserialize(data) is None
+
+    def test_boolean_values(self, serializer):
+        for v in [True, False]:
+            data = serializer.serialize(v)
+            restored = serializer.deserialize(data)
+            assert restored is v or restored == v
+            assert isinstance(restored, bool)
+
+    def test_integer_edge_cases(self, serializer):
+        for v in [0, 1, -1, 2**31 - 1, -(2**31), 2**63 - 1, -(2**63)]:
+            data = serializer.serialize(v)
+            restored = serializer.deserialize(data)
+            assert restored == v
+            assert type(restored) is type(v)
+
+    def test_float_edge_cases(self, serializer):
+        for v in [0.0, -0.0, 3.141592653589793, float("inf"),
+                  float("-inf"), 1.7976931348623157e308, 5e-324]:
+            if math.isnan(v):
+                continue  # NaN comparison is tricky
+            data = serializer.serialize(v)
+            restored = serializer.deserialize(data)
+            if isinstance(restored, float) and math.isnan(v):
+                assert math.isnan(restored)
+            else:
+                assert restored == v
+
+    def test_deeply_nested_structure(self, serializer):
+        v = {"level1": {"level2": {"level3": {"level4": {"level5": "deep"}}}}}
+        data = serializer.serialize(v)
+        restored = serializer.deserialize(data)
+        assert restored == v
+
+    def test_large_list_of_small_dicts(self, serializer):
+        v = [{"id": i, "val": str(i)} for i in range(10000)]
+        data = serializer.serialize(v)
+        restored = serializer.deserialize(data)
+        assert restored == v
+        assert len(restored) == 10000
+
+
+class TestCacheSerializerInvalidInput:
+    """Error handling for invalid/unsupported inputs."""
+
+    def test_unknown_format(self):
+        with pytest.raises(ValueError, match="Unknown serializer format"):
+            CacheSerializer(format="xml")
+
+    def test_msgpack_not_installed(self):
+        import sys
+        # Simulate missing msgpack by checking if we can bypass it
+        try:
+            import msgpack  # noqa: F401
+            pytest.skip("msgpack is installed, can't test missing case")
+        except ImportError:
+            with pytest.raises(ImportError, match="msgpack"):
+                CacheSerializer(format="msgpack")
+
+    def test_unserializable_object_json(self):
+        """JSON serializer can't handle arbitrary objects."""
+        ser = CacheSerializer(format="json")
+
+        class Unserializable:
+            pass
+
+        with pytest.raises(TypeError):
+            ser.serialize(Unserializable())
+
+    def test_circular_reference_json(self):
+        """JSON serializer should raise on circular refs."""
+        ser = CacheSerializer(format="json")
+        v: Dict[str, Any] = {"key": None}
+        v["key"] = v
+        with pytest.raises((ValueError, TypeError)):
+            ser.serialize(v)
+
+    def test_pickle_serializer_warning(self):
+        with pytest.warns(UserWarning, match="unsafe"):
+            CacheSerializer(format="pickle")
+
+
+class TestCacheSerializerCrossFormat:
+    """Data serialized in one format should not be expected to
+    deserialize correctly in another (negative testing)."""
+
+    def test_json_data_cannot_be_read_by_pickle(self):
+        ser_json = CacheSerializer(format="json")
+        data = ser_json.serialize("hello")
+        ser_pickle = CacheSerializer(format="pickle")
+        with pytest.raises(Exception):
+            ser_pickle.deserialize(data)
+
+    def test_pickle_data_cannot_be_read_by_json(self):
+        ser_pickle = CacheSerializer(format="pickle")
+        data = ser_pickle.serialize("hello")
+        ser_json = CacheSerializer(format="json")
+        with pytest.raises(Exception):
+            ser_json.deserialize(data)
+
+
+class TestCacheSerializerFormatProperty:
+    """Serializer exposes its format."""
+
+    def test_format_property(self):
+        assert CacheSerializer(format="json").format == "json"
+        assert CacheSerializer(format="pickle").format == "pickle"
+        assert CacheSerializer().format == "json"
+
+    def test_case_insensitive(self):
+        assert CacheSerializer(format="JSON").format == "json"
+        assert CacheSerializer(format="Pickle").format == "pickle"

--- a/tests/rhosocial/activerecord_test/feature/relation/test_derived_field.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_derived_field.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_derived_field.py
+"""
+Bridge file for derived field tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_derived_field import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_derived_field_async.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_derived_field_async.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_derived_field_async.py
+"""
+Bridge file for async derived field tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_derived_field_async import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_derived_field_json.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_derived_field_json.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_derived_field_json.py
+"""
+Bridge file for JSON derived field tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_derived_field_json import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_derived_field_json_async.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_derived_field_json_async.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_derived_field_json_async.py
+"""
+Bridge file for async JSON derived field tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_derived_field_json_async import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_descriptor_coverage.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_descriptor_coverage.py
@@ -1,0 +1,731 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_descriptor_coverage.py
+"""
+Targeted tests to cover uncovered code paths in descriptors.py and async_descriptors.py.
+Also identifies dead code.
+"""
+import sys
+import inspect
+from typing import ClassVar, ForwardRef, Any, Optional, List, Dict
+
+import pytest
+from pydantic import BaseModel
+
+from rhosocial.activerecord.relation.base import RelationManagementMixin
+from rhosocial.activerecord.relation.descriptors import (
+    BelongsTo, HasOne, HasMany, RelationDescriptor,
+    RelationshipValidator, DefaultIRelationLoader, _evaluate_forward_ref,
+)
+from rhosocial.activerecord.relation.async_descriptors import (
+    AsyncBelongsTo, AsyncHasOne, AsyncHasMany, AsyncRelationDescriptor,
+    AsyncRelationshipValidator, AsyncDefaultRelationLoader,
+)
+from rhosocial.activerecord.relation.cache import CacheConfig, InstanceCache
+from rhosocial.activerecord.relation.interfaces import IRelationLoader, IAsyncRelationLoader
+
+
+# ==============================================================================
+# 1. __init__ validation paths
+# ==============================================================================
+
+class TestDescriptorInit:
+    """Cover __init__ validation branches."""
+
+    def test_sync_invalid_foreign_key_type(self):
+        with pytest.raises(TypeError, match="foreign_key must be a string"):
+            BelongsTo(foreign_key=123)
+
+    def test_sync_invalid_cache_config_type(self):
+        with pytest.raises(TypeError, match="cache_config must be instance of CacheConfig"):
+            BelongsTo(foreign_key="x_id", cache_config="not_a_cache_config")  # type: ignore
+
+    def test_async_invalid_foreign_key_type(self):
+        with pytest.raises(TypeError, match="foreign_key must be a string"):
+            AsyncBelongsTo(foreign_key=123)
+
+    def test_async_invalid_cache_config_type(self):
+        with pytest.raises(TypeError, match="cache_config must be instance of CacheConfig"):
+            AsyncBelongsTo(foreign_key="x_id", cache_config="not_a_cache_config")  # type: ignore
+
+
+# ==============================================================================
+# 2. __set_name__ type checking
+# ==============================================================================
+
+class TestSetNameTypeCheck:
+    """Cover the type-check guard in __set_name__."""
+
+    def test_sync_descriptor_on_async_model_raises(self):
+        """Sync BelongsTo on async model should raise TypeError."""
+        from rhosocial.activerecord.interface import IAsyncActiveRecord
+
+        # Use type() to bypass Pydantic's metaclass
+        FakeAsyncModel = type('FakeAsyncModel', (IAsyncActiveRecord,), {})
+        desc = BelongsTo(foreign_key="x_id")
+        with pytest.raises(TypeError, match="Sync relation descriptor.*cannot be used on async model"):
+            desc.__set_name__(FakeAsyncModel, "test_rel")
+
+    def test_async_descriptor_on_sync_model_raises(self):
+        """Async descriptor on sync ActiveRecord should raise TypeError."""
+        from rhosocial.activerecord.interface import IActiveRecord
+
+        # Use type() to bypass Pydantic's metaclass
+        FakeSyncModel = type('FakeSyncModel', (IActiveRecord,), {})
+        desc = AsyncBelongsTo(foreign_key="x_id")
+        with pytest.raises(TypeError, match="Async relation descriptor.*cannot be used on sync model"):
+            desc.__set_name__(FakeSyncModel, "test_rel")
+
+
+# ==============================================================================
+# 3. __get__ class-level access
+# ==============================================================================
+
+class TestDescriptorGetClassLevel:
+    """Cover __get__ with instance=None path."""
+
+    def test_sync_get_on_class_returns_self(self):
+        class Dept(RelationManagementMixin, BaseModel):
+            id: int
+            name: str
+            employees: ClassVar[HasMany["Emp"]] = HasMany(
+                foreign_key="dept_id", inverse_of="department"
+            )
+
+        class Emp(RelationManagementMixin, BaseModel):
+            id: int
+            dept_id: int
+            department: ClassVar[BelongsTo["Dept"]] = BelongsTo(
+                foreign_key="dept_id", inverse_of="employees"
+            )
+
+        descriptor = Dept.__dict__["employees"]
+        result = descriptor.__get__(None, Dept)
+        assert result is descriptor
+
+    def test_async_get_on_class_returns_self(self):
+        class Dept(RelationManagementMixin, BaseModel):
+            id: int
+            name: str
+            employees: ClassVar[AsyncHasMany["Emp"]] = AsyncHasMany(
+                foreign_key="dept_id", inverse_of="department"
+            )
+
+        class Emp(RelationManagementMixin, BaseModel):
+            id: int
+            dept_id: int
+            department: ClassVar[AsyncBelongsTo["Dept"]] = AsyncBelongsTo(
+                foreign_key="dept_id", inverse_of="employees"
+            )
+
+        descriptor = Dept.__dict__["employees"]
+        result = descriptor.__get__(None, Dept)
+        assert result is descriptor
+
+
+# ==============================================================================
+# 4. __delete__
+# ==============================================================================
+
+class TestDescriptorDelete:
+    """Cover __delete__ path."""
+
+    def test_sync_delete_clears_cache(self):
+        class Owner(RelationManagementMixin, BaseModel):
+            id: int
+            items: ClassVar[HasMany["Item"]] = HasMany(
+                foreign_key="owner_id", inverse_of="owner"
+            )
+
+        class Item(RelationManagementMixin, BaseModel):
+            id: int
+            owner_id: int
+            owner: ClassVar[BelongsTo["Owner"]] = BelongsTo(
+                foreign_key="owner_id", inverse_of="items"
+            )
+
+        instance = Owner(id=1)
+        InstanceCache.set(instance, "items", [Item(id=1, owner_id=1)], CacheConfig())
+        assert InstanceCache.get(instance, "items", CacheConfig()) is not None
+
+        descriptor = Owner.__dict__["items"]
+        descriptor.__delete__(instance)
+        assert InstanceCache.get(instance, "items", CacheConfig()) is None
+
+    def test_async_delete_clears_cache(self):
+        class Owner(RelationManagementMixin, BaseModel):
+            id: int
+            items: ClassVar[AsyncHasMany["Item"]] = AsyncHasMany(
+                foreign_key="owner_id", inverse_of="owner"
+            )
+
+        class Item(RelationManagementMixin, BaseModel):
+            id: int
+            owner_id: int
+            owner: ClassVar[AsyncBelongsTo["Owner"]] = AsyncBelongsTo(
+                foreign_key="owner_id", inverse_of="items"
+            )
+
+        instance = Owner(id=1)
+        InstanceCache.set(instance, "items", [Item(id=1, owner_id=1)], CacheConfig())
+        assert InstanceCache.get(instance, "items", CacheConfig()) is not None
+
+        descriptor = Owner.__dict__["items"]
+        descriptor.__delete__(instance)
+        assert InstanceCache.get(instance, "items", CacheConfig()) is None
+
+
+# ==============================================================================
+# 5. _load_relation paths (cache hit, loader error)
+# ==============================================================================
+
+class FakeSyncLoader(IRelationLoader):
+    def __init__(self, return_value=None, raise_error=False):
+        self.return_value = return_value
+        self.raise_error = raise_error
+        self.load_called = False
+
+    def load(self, instance):
+        self.load_called = True
+        if self.raise_error:
+            raise RuntimeError("loader failed")
+        return self.return_value
+
+    def batch_load(self, instances, base_query):
+        return {id(instances[0]): self.return_value}
+
+
+class TestLoadRelation:
+    """Cover _load_relation cache hit, miss, and error paths."""
+
+    def test_sync_load_cache_hit(self):
+        data = {"id": 1}
+        loader = FakeSyncLoader(return_value=data)
+
+        class Target(RelationManagementMixin, BaseModel):
+            id: int
+
+        class Source(RelationManagementMixin, BaseModel):
+            id: int
+            target_id: int
+            target: ClassVar[BelongsTo["Target"]] = BelongsTo(
+                foreign_key="target_id", loader=loader
+            )
+
+        instance = Source(id=1, target_id=1)
+        # Pre-set cache
+        InstanceCache.set(instance, "target", data, CacheConfig())
+        # Access via descriptor
+        result = instance.target()
+        assert result == data
+        assert not loader.load_called
+
+    def test_sync_load_cache_miss(self):
+        class Target(RelationManagementMixin, BaseModel):
+            id: int
+            name: str
+
+        data = Target(id=1, name="test")
+        loader = FakeSyncLoader(return_value=data)
+
+        class Source(RelationManagementMixin, BaseModel):
+            id: int
+            target_id: int
+            target: ClassVar[BelongsTo["Target"]] = BelongsTo(
+                foreign_key="target_id", loader=loader
+            )
+
+        instance = Source(id=1, target_id=1)
+        result = instance.target()
+        assert result == data
+        assert loader.load_called
+
+    def test_sync_load_loader_error_returns_none(self):
+        loader = FakeSyncLoader(raise_error=True)
+
+        class Target(RelationManagementMixin, BaseModel):
+            id: int
+
+        class Source(RelationManagementMixin, BaseModel):
+            id: int
+            target_id: int
+            target: ClassVar[BelongsTo["Target"]] = BelongsTo(
+                foreign_key="target_id", loader=loader
+            )
+
+        instance = Source(id=1, target_id=1)
+        result = instance.target()
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_async_load_cache_hit(self):
+        class Target(RelationManagementMixin, BaseModel):
+            id: int
+
+        data = {"id": 1}
+        loader = FakeSyncLoader(return_value=data)
+
+        class Source(RelationManagementMixin, BaseModel):
+            id: int
+            target_id: int
+            target: ClassVar[AsyncBelongsTo["Target"]] = AsyncBelongsTo(
+                foreign_key="target_id", loader=loader
+            )
+
+        instance = Source(id=1, target_id=1)
+        InstanceCache.set(instance, "target", data, CacheConfig())
+        result = await instance.target()
+        assert result == data
+
+
+# ==============================================================================
+# 6. _create_relation_method with args — exercises dead self._query path
+# ==============================================================================
+
+class TestCreateRelationMethodNoArgs:
+    """_create_relation_method no longer accepts args (dead code removed)."""
+
+    def test_sync_relation_method_rejects_args(self):
+        class Target(RelationManagementMixin, BaseModel):
+            id: int
+
+        class Source(RelationManagementMixin, BaseModel):
+            id: int
+            target_id: int
+            target: ClassVar[BelongsTo["Target"]] = BelongsTo(
+                foreign_key="target_id"
+            )
+
+        instance = Source(id=1, target_id=1)
+        method = Source.target.__get__(instance, Source)
+        with pytest.raises(TypeError):
+            method(some_arg="value")
+
+    @pytest.mark.asyncio
+    async def test_async_relation_method_rejects_args(self):
+        class Target(RelationManagementMixin, BaseModel):
+            id: int
+
+        class Source(RelationManagementMixin, BaseModel):
+            id: int
+            target_id: int
+            target: ClassVar[AsyncBelongsTo["Target"]] = AsyncBelongsTo(
+                foreign_key="target_id"
+            )
+
+        instance = Source(id=1, target_id=1)
+        method = Source.target.__get__(instance, Source)
+        with pytest.raises(TypeError):
+            await method(some_arg="value")
+
+
+# ==============================================================================
+# 7. _evaluate_forward_ref
+# ==============================================================================
+
+class TestEvaluateForwardRef:
+    """Cover _evaluate_forward_ref function."""
+
+    def test_evaluate_string_ref(self):
+        class DummyModel(RelationManagementMixin, BaseModel):
+            id: int
+
+        result = _evaluate_forward_ref("DummyModel", DummyModel)
+        assert result is DummyModel
+
+    def test_evaluate_forward_ref_direct(self):
+        class DummyModel(RelationManagementMixin, BaseModel):
+            id: int
+
+        ref = ForwardRef("DummyModel")
+        # ensure it's in the module scope for resolution
+        result = _evaluate_forward_ref(ref, DummyModel)
+        assert result is DummyModel
+
+    def test_evaluate_forward_ref_with_module_scope(self):
+        """Test that forward ref resolves using module globals."""
+        class DummyModel(RelationManagementMixin, BaseModel):
+            id: int
+
+        ref = ForwardRef("BaseModel")
+        result = _evaluate_forward_ref(ref, DummyModel)
+        assert result is BaseModel
+
+
+# ==============================================================================
+# 8. RelationshipValidator / AsyncRelationshipValidator
+# ==============================================================================
+
+class TestRelationshipValidatorPaths:
+    """Cover RelationshipValidator validation branches."""
+
+    def test_valid_belongs_to_has_many_pair(self):
+        class Dept(RelationManagementMixin, BaseModel):
+            id: int
+            employees: ClassVar[HasMany["Emp"]] = HasMany(
+                foreign_key="dept_id", inverse_of="department"
+            )
+
+        class Emp(RelationManagementMixin, BaseModel):
+            id: int
+            dept_id: int
+            department: ClassVar[BelongsTo["Dept"]] = BelongsTo(
+                foreign_key="dept_id", inverse_of="employees"
+            )
+        # Trigger validation by accessing relation
+        Emp(id=1, dept_id=1).department()
+
+    def test_valid_belongs_to_has_one_pair(self):
+        class User(RelationManagementMixin, BaseModel):
+            id: int
+            profile: ClassVar[HasOne["Profile"]] = HasOne(
+                foreign_key="user_id", inverse_of="user"
+            )
+
+        class Profile(RelationManagementMixin, BaseModel):
+            id: int
+            user_id: int
+            user: ClassVar[BelongsTo["User"]] = BelongsTo(
+                foreign_key="user_id", inverse_of="profile"
+            )
+        # Trigger validation
+        Profile(id=1, user_id=1).user()
+
+    def test_invalid_has_many_has_many_pair(self):
+        """HasMany↔HasMany should fail validation on relation access."""
+        class A(RelationManagementMixin, BaseModel):
+            id: int
+            bs: ClassVar[HasMany["B"]] = HasMany(
+                foreign_key="a_id", inverse_of="a"
+            )
+
+        class B(RelationManagementMixin, BaseModel):
+            id: int
+            a_id: int
+            a: ClassVar[HasMany["A"]] = HasMany(
+                foreign_key="a_id", inverse_of="bs"
+            )
+
+        # Validation is lazy — triggered on relation access
+        with pytest.raises(ValueError, match="Invalid relationship pair"):
+            A(id=1).bs()
+
+    def test_auto_set_inverse_of(self):
+        """When inverse_of is None on the related model, it should be auto-set."""
+        class A(RelationManagementMixin, BaseModel):
+            id: int
+            bs: ClassVar[HasMany["B"]] = HasMany(
+                foreign_key="a_id", inverse_of="a"
+            )
+
+        class B(RelationManagementMixin, BaseModel):
+            id: int
+            a_id: int
+            a: ClassVar[BelongsTo["A"]] = BelongsTo(
+                foreign_key="a_id"
+            )
+        # Trigger validation by accessing the relation
+        A(id=1).bs()
+        assert B.get_relation("a").inverse_of == "bs"
+
+    def test_async_valid_belongs_to_has_many_pair(self):
+        class Dept(RelationManagementMixin, BaseModel):
+            id: int
+            employees: ClassVar[AsyncHasMany["Emp"]] = AsyncHasMany(
+                foreign_key="dept_id", inverse_of="department"
+            )
+
+        class Emp(RelationManagementMixin, BaseModel):
+            id: int
+            dept_id: int
+            department: ClassVar[AsyncBelongsTo["Dept"]] = AsyncBelongsTo(
+                foreign_key="dept_id", inverse_of="employees"
+            )
+
+    def test_missing_inverse_relationship(self):
+        """Inverse name does not exist on related model."""
+        class A(RelationManagementMixin, BaseModel):
+            id: int
+            bs: ClassVar[HasMany["B"]] = HasMany(
+                foreign_key="a_id", inverse_of="nonexistent"
+            )
+
+        class B(RelationManagementMixin, BaseModel):
+            id: int
+            a_id: int
+
+        with pytest.raises(ValueError, match="Inverse relationship.*not found"):
+            A(id=1).bs()
+
+    def test_non_relation_inverse(self):
+        """Inverse exists but is not a RelationDescriptor."""
+        class A(RelationManagementMixin, BaseModel):
+            id: int
+            bs: ClassVar[HasMany["B"]] = HasMany(
+                foreign_key="a_id", inverse_of="a"
+            )
+
+        class B(RelationManagementMixin, BaseModel):
+            id: int
+            a_id: int
+            a: ClassVar[str] = "not_a_descriptor"
+
+        with pytest.raises(ValueError, match="must be a RelationDescriptor"):
+            A(id=1).bs()
+
+    def test_async_missing_inverse_relationship(self):
+        """Inverse name does not exist on related model."""
+        class A(RelationManagementMixin, BaseModel):
+            id: int
+            bs: ClassVar[AsyncHasMany["B"]] = AsyncHasMany(
+                foreign_key="a_id", inverse_of="nonexistent"
+            )
+
+        class B(RelationManagementMixin, BaseModel):
+            id: int
+            a_id: int
+
+        with pytest.raises(ValueError, match="Inverse relationship.*not found"):
+            A(id=1).bs()
+
+    def test_async_auto_set_inverse_of(self):
+        class A(RelationManagementMixin, BaseModel):
+            id: int
+            bs: ClassVar[AsyncHasMany["B"]] = AsyncHasMany(
+                foreign_key="a_id", inverse_of="a"
+            )
+
+        class B(RelationManagementMixin, BaseModel):
+            id: int
+            a_id: int
+            a: ClassVar[AsyncBelongsTo["A"]] = AsyncBelongsTo(
+                foreign_key="a_id"
+            )
+        # Trigger validation via get_related_model directly (avoids coroutine)
+        desc = A.get_relation("bs")
+        desc.get_related_model(A)
+        assert B.get_relation("a").inverse_of == "bs"
+
+
+    def test_inconsistent_inverse_wrong_owner(self):
+        """Trigger 'Inconsistent inverse' by validating with an unrelated owner.
+
+        WARNING: This simulates an unnatural scenario where validate() is called
+        with an owner class that does NOT own the descriptor. Under normal class
+        definition this path is unreachable, because validate() is only invoked
+        from __set_name__, which always passes the actual owner class.
+        Do NOT replicate this pattern in application code.
+        """
+        class A(RelationManagementMixin, BaseModel):
+            id: int
+            bs: ClassVar[HasMany["B"]] = HasMany(
+                foreign_key="a_id", inverse_of="a"
+            )
+
+        class B(RelationManagementMixin, BaseModel):
+            id: int
+            a_id: int
+            a: ClassVar[BelongsTo["A"]] = BelongsTo(
+                foreign_key="a_id", inverse_of="bs"
+            )
+
+        # After B's validation, A.bs.inverse_of was auto-set to 'a'.
+        # Now call A.bs's validator with an unrelated owner class C.
+        class C(RelationManagementMixin, BaseModel):
+            id: int
+
+        with pytest.raises(ValueError, match="Inconsistent inverse"):
+            A.get_relation("bs")._validator.validate(C, B)
+
+    def test_async_inconsistent_inverse_wrong_owner(self):
+        """Async: trigger 'Inconsistent inverse' via unrelated owner.
+
+        WARNING: Same unnatural scenario as the sync version. Do NOT replicate
+        in application code.
+        """
+        class A(RelationManagementMixin, BaseModel):
+            id: int
+            bs: ClassVar[AsyncHasMany["B"]] = AsyncHasMany(
+                foreign_key="a_id", inverse_of="a"
+            )
+
+        class B(RelationManagementMixin, BaseModel):
+            id: int
+            a_id: int
+            a: ClassVar[AsyncBelongsTo["A"]] = AsyncBelongsTo(
+                foreign_key="a_id", inverse_of="bs"
+            )
+
+        class C(RelationManagementMixin, BaseModel):
+            id: int
+
+        with pytest.raises(ValueError, match="Inconsistent inverse"):
+            A.get_relation("bs")._validator.validate(C, B)
+
+
+# ==============================================================================
+# 9. DefaultIRelationLoader & AsyncDefaultRelationLoader — basic init
+# ==============================================================================
+
+class TestDefaultLoadersInit:
+    """Default loaders are created internally; verify existence."""
+
+    def test_sync_default_loader_created(self):
+        desc = BelongsTo(foreign_key="x_id")
+        loader = desc._loader
+        assert isinstance(loader, DefaultIRelationLoader)
+        assert loader.descriptor is desc
+
+    def test_async_default_loader_created(self):
+        desc = AsyncBelongsTo(foreign_key="x_id")
+        loader = desc._loader
+        assert isinstance(loader, AsyncDefaultRelationLoader)
+        assert loader.descriptor is desc
+
+
+# ==============================================================================
+# 10. _create_query_method coverage via descriptor
+# ==============================================================================
+
+class TestCreateQueryMethod:
+    """Cover _create_query_method for both BelongsTo and HasOne/HasMany."""
+
+    def test_query_method_exists(self):
+        class Target(RelationManagementMixin, BaseModel):
+            id: int
+
+        class Source(RelationManagementMixin, BaseModel):
+            id: int
+            target_id: int
+            target: ClassVar[BelongsTo["Target"]] = BelongsTo(
+                foreign_key="target_id"
+            )
+
+        assert hasattr(Source, "target_query")
+        query_method = Source.target_query
+        # Calling requires a proper instance with backend → skip call, just check existence.
+
+    def test_async_query_method_exists(self):
+        class Target(RelationManagementMixin, BaseModel):
+            id: int
+
+        class Source(RelationManagementMixin, BaseModel):
+            id: int
+            target_id: int
+            target: ClassVar[AsyncBelongsTo["Target"]] = AsyncBelongsTo(
+                foreign_key="target_id"
+            )
+
+        assert hasattr(Source, "target_query")
+
+
+# ==============================================================================
+# 11. batch_load on RelationDescriptor / AsyncRelationDescriptor
+# ==============================================================================
+
+class TestDescriptorBatchLoad:
+    """Cover RelationDescriptor.batch_load with empty records."""
+
+    def test_sync_batch_load_empty_records(self):
+        desc = BelongsTo(foreign_key="x_id")
+        desc.name = "test_rel"
+        result = desc.batch_load([], None)
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_async_batch_load_empty_records(self):
+        desc = AsyncBelongsTo(foreign_key="x_id")
+        desc.name = "test_rel"
+        result = await desc.batch_load([], None)
+        assert result == {}
+
+
+# ==============================================================================
+# 12. log method with offset
+# ==============================================================================
+
+class TestLogMethod:
+    """Cover the log method's offset handling."""
+
+    def test_log_with_offset(self):
+        desc = BelongsTo(foreign_key="x_id")
+        # Should not crash even without _owner
+        desc.log(10, "test message", offset=2)
+
+
+# ==============================================================================
+# 13. Resolve model type from annotations with ClassVar
+# ==============================================================================
+
+class TestResolveModel:
+    """Cover _resolve_model with different annotation patterns."""
+
+    def test_sync_resolve_belongs_to(self):
+        class Target(RelationManagementMixin, BaseModel):
+            id: int
+
+        class Source(RelationManagementMixin, BaseModel):
+            id: int
+            target_id: int
+            target: ClassVar[BelongsTo["Target"]] = BelongsTo(
+                foreign_key="target_id"
+            )
+
+        desc = Source.get_relation("target")
+        model = desc.get_related_model(Source)
+        assert model is Target
+
+    def test_async_resolve_belongs_to(self):
+        class Target(RelationManagementMixin, BaseModel):
+            id: int
+
+        class Source(RelationManagementMixin, BaseModel):
+            id: int
+            target_id: int
+            target: ClassVar[AsyncBelongsTo["Target"]] = AsyncBelongsTo(
+                foreign_key="target_id"
+            )
+
+        desc = Source.get_relation("target")
+        model = desc.get_related_model(Source)
+        assert model is Target
+
+
+# ==============================================================================
+# 14. clear_cache on the bound relation method
+# ==============================================================================
+
+class TestRelationMethodClearCache:
+    """Cover the clear_cache lambda on relation methods."""
+
+    def test_sync_clear_cache(self):
+        class Target(RelationManagementMixin, BaseModel):
+            id: int
+
+        class Source(RelationManagementMixin, BaseModel):
+            id: int
+            target_id: int
+            target: ClassVar[BelongsTo["Target"]] = BelongsTo(
+                foreign_key="target_id"
+            )
+
+        instance = Source(id=1, target_id=1)
+        InstanceCache.set(instance, "target", Target(id=1), CacheConfig())
+        method = Source.target.__get__(instance, Source)
+        method.clear_cache()
+        assert InstanceCache.get(instance, "target", CacheConfig()) is None
+
+    def test_async_clear_cache(self):
+        class Target(RelationManagementMixin, BaseModel):
+            id: int
+
+        class Source(RelationManagementMixin, BaseModel):
+            id: int
+            target_id: int
+            target: ClassVar[AsyncBelongsTo["Target"]] = AsyncBelongsTo(
+                foreign_key="target_id"
+            )
+
+        instance = Source(id=1, target_id=1)
+        InstanceCache.set(instance, "target", Target(id=1), CacheConfig())
+        method = Source.target.__get__(instance, Source)
+        method.clear_cache()
+        assert InstanceCache.get(instance, "target", CacheConfig()) is None

--- a/tests/rhosocial/activerecord_test/feature/relation/test_descriptor_db_coverage.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_descriptor_db_coverage.py
@@ -210,6 +210,17 @@ class TestLoadRelationDb:
         results = post.comments()
         assert len(results) == 1
 
+    def test_cache_write_failure_still_returns_loaded_data(self, user_post_comment_classes, mocker):
+        user_class, post_class, comment_class = user_post_comment_classes
+        user = user_class(name="Peggy"); user.save()
+        post = post_class(title="CacheWriteFail", body="B", user_id=user.id); post.save()
+
+        mocker.patch.object(InstanceCache, "set", side_effect=TypeError("cache write failed"))
+
+        results = user.posts()
+        assert len(results) == 1
+        assert results[0].id == post.id
+
 
 # ==============================================================================
 # Async DefaultIRelationLoader

--- a/tests/rhosocial/activerecord_test/feature/relation/test_descriptor_db_coverage.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_descriptor_db_coverage.py
@@ -1,0 +1,302 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_descriptor_db_coverage.py
+"""
+Database-backed tests covering descriptor code paths that require SQLite.
+
+Covers: _create_query_method, _load_relation, DefaultIRelationLoader.load/batch_load,
+RelationDescriptor.batch_load, cache interaction, HasOne path.
+"""
+import pytest
+from typing import Dict, Any, List
+
+from rhosocial.activerecord.relation.cache import CacheConfig, InstanceCache
+from rhosocial.activerecord.relation.descriptors import DefaultIRelationLoader, BelongsTo, HasMany, HasOne
+from rhosocial.activerecord.relation.async_descriptors import (
+    AsyncDefaultRelationLoader, AsyncBelongsTo, AsyncHasMany, AsyncHasOne,
+)
+
+
+# ==============================================================================
+# _create_query_method — calls model_class.query() with FK/PK filter
+# ==============================================================================
+
+class TestCreateQueryMethod:
+    """Cover _create_query_method for BelongsTo, HasMany, HasOne."""
+
+    def _save(self, model):
+        model.save()
+        return model
+
+    def test_belongs_to_query_method(self, user_post_comment_classes):
+        """BelongsTo query filters by FK matching instance PK."""
+        user_class, post_class, comment_class = user_post_comment_classes
+        user = user_class(name="Alice")
+        user.save()
+        post = post_class(title="Post", body="Body", user_id=user.id)
+        post.save()
+
+        query = post.user_query()
+        assert user.id is not None
+        results = query.all()
+        assert len(results) == 1
+        assert results[0].id == user.id
+
+    def test_has_many_query_method(self, user_post_comment_classes):
+        """HasMany query filters by FK matching instance PK."""
+        user_class, post_class, comment_class = user_post_comment_classes
+        user = user_class(name="Bob")
+        user.save()
+        p1 = post_class(title="Post A", body="Body", user_id=user.id)
+        p1.save()
+        p2 = post_class(title="Post B", body="Body", user_id=user.id)
+        p2.save()
+
+        query = user.posts_query()
+        results = query.all()
+        assert len(results) == 2
+
+    def test_has_one_query_method(self, user_post_comment_classes):
+        """HasOne query method exists and can be called."""
+        user_class, post_class, comment_class = user_post_comment_classes
+        user = user_class(name="Carol")
+        user.save()
+        query = user.posts_query()
+        assert query is not None
+        assert user.id is not None
+
+
+# ==============================================================================
+# DefaultIRelationLoader.batch_load — BelongsTo path
+# ==============================================================================
+
+class TestDefaultLoaderBelongsTo:
+    """Cover DefaultIRelationLoader.batch_load for BelongsTo."""
+
+    def test_belongs_to_load_single(self, user_post_comment_classes):
+        """BelongsTo: comment loads its post."""
+        user_class, post_class, comment_class = user_post_comment_classes
+        user = user_class(name="Dave"); user.save()
+        post = post_class(title="Test", body="Body", user_id=user.id); post.save()
+        comment = comment_class(body="Nice!", post_id=post.id); comment.save()
+
+        result = comment.post()
+        assert result is not None
+        assert result.id == post.id
+        assert result.title == "Test"
+
+    def test_belongs_to_batch_load(self, user_post_comment_classes):
+        """BelongsTo batch_load: multiple comments share/span posts."""
+        user_class, post_class, comment_class = user_post_comment_classes
+        user = user_class(name="Eve"); user.save()
+        post1 = post_class(title="P1", body="B1", user_id=user.id); post1.save()
+        post2 = post_class(title="P2", body="B2", user_id=user.id); post2.save()
+
+        c1 = comment_class(body="C1", post_id=post1.id); c1.save()
+        c2 = comment_class(body="C2", post_id=post1.id); c2.save()
+        c3 = comment_class(body="C3", post_id=post2.id); c3.save()
+
+        result = c2.post()
+        assert result is not None
+        assert result.id == post1.id
+
+
+
+
+# ==============================================================================
+# DefaultIRelationLoader.batch_load — HasMany path
+# ==============================================================================
+
+class TestDefaultLoaderHasMany:
+    """Cover DefaultIRelationLoader.batch_load for HasMany."""
+
+    def test_has_many_load(self, user_post_comment_classes):
+        """HasMany: user loads posts."""
+        user_class, post_class, comment_class = user_post_comment_classes
+        user = user_class(name="Heidi"); user.save()
+        p1 = post_class(title="A", body="B1", user_id=user.id); p1.save()
+        p2 = post_class(title="B", body="B2", user_id=user.id); p2.save()
+
+        results = user.posts()
+        assert len(results) == 2
+
+    def test_has_many_empty(self, user_post_comment_classes):
+        """HasMany: user with no posts returns []."""
+        user_class, post_class, comment_class = user_post_comment_classes
+        user = user_class(name="Ivan"); user.save()
+
+        results = user.posts()
+        assert results == []
+
+    def test_has_many_batch_multiple_users(self, user_post_comment_classes):
+        """HasMany: multiple users with posts."""
+        user_class, post_class, comment_class = user_post_comment_classes
+        u1 = user_class(name="Judy"); u1.save()
+        u2 = user_class(name="Karl"); u2.save()
+        p1 = post_class(title="U1P1", body="B", user_id=u1.id); p1.save()
+        p2 = post_class(title="U2P1", body="B", user_id=u2.id); p2.save()
+        p3 = post_class(title="U2P2", body="B", user_id=u2.id); p3.save()
+
+        r1 = u1.posts()
+        assert len(r1) == 1
+        r2 = u2.posts()
+        assert len(r2) == 2
+
+
+# ==============================================================================
+# DefaultIRelationLoader.batch_load — HasOne path
+# ==============================================================================
+
+class TestDefaultLoaderHasOne:
+    """Cover DefaultIRelationLoader.batch_load for HasOne."""
+
+    def test_has_one_load(self, user_post_comment_classes):
+        """HasOne — default loader branching is identical to HasMany for WHERE.
+
+        The actual HasOne-vs-HasMany distinction in batch_load is just
+        taking result[0] vs result list. Verify HasMany path works.
+        """
+        user_class, post_class, comment_class = user_post_comment_classes
+        user = user_class(name="Leo"); user.save()
+        p1 = post_class(title="H1", body="B", user_id=user.id); p1.save()
+        results = user.posts()
+        assert len(results) == 1
+
+
+# ==============================================================================
+# _load_relation — cache interaction
+# ==============================================================================
+
+class TestLoadRelationDb:
+    """Cover _load_relation with cache hit/miss/error using DB loader."""
+
+    def test_cache_hit_after_initial_load(self, user_post_comment_classes):
+        """Second access uses cache."""
+        user_class, post_class, comment_class = user_post_comment_classes
+        user = user_class(name="Mallory"); user.save()
+        p = post_class(title="Cached", body="B", user_id=user.id); p.save()
+
+        results = user.posts()
+        assert len(results) == 1
+
+        results2 = user.posts()
+        assert len(results2) == 1
+
+    def test_cache_bypass_with_disabled_cache(self, user_post_comment_classes):
+        """When cache is disabled, each access reloads."""
+        user_class, post_class, comment_class = user_post_comment_classes
+        user = user_class(name="Nina"); user.save()
+
+        desc = user_class.get_relation("posts")
+        config = desc._cache_config
+        desc._cache_config = CacheConfig(enabled=False)
+
+        p = post_class(title="NoCache", body="B", user_id=user.id); p.save()
+        r1 = user.posts()
+        assert len(r1) == 1
+
+        desc._cache_config = config
+
+    def test_cache_cleared_on_delete(self, user_post_comment_classes):
+        """__delete__ clears the instance cache."""
+        user_class, post_class, comment_class = user_post_comment_classes
+        user = user_class(name="Oscar"); user.save()
+        post = post_class(title="Del", body="B", user_id=user.id); post.save()
+        c = comment_class(body="C", post_id=post.id); c.save()
+
+        _ = post.comments()
+
+        desc = post_class.get_relation("comments")
+        desc.__delete__(post)
+
+        results = post.comments()
+        assert len(results) == 1
+
+
+# ==============================================================================
+# Async DefaultIRelationLoader
+# ==============================================================================
+
+class TestAsyncDefaultLoader:
+    """Cover AsyncDefaultRelationLoader with DB."""
+
+    @pytest.mark.asyncio
+    async def test_async_belongs_to_load(self, async_user_post_comment_classes):
+        user_class, post_class, comment_class = async_user_post_comment_classes
+        user = user_class(name="AsyncAlice"); await user.save()
+        post = post_class(title="AsyncPost", body="Body", user_id=user.id); await post.save()
+        comment = comment_class(body="Nice", post_id=post.id); await comment.save()
+
+        result = await comment.post()
+        assert result is not None
+        assert result.id == post.id
+
+    @pytest.mark.asyncio
+    async def test_async_has_many_load(self, async_user_post_comment_classes):
+        user_class, post_class, comment_class = async_user_post_comment_classes
+        user = user_class(name="AsyncBob"); await user.save()
+        p1 = post_class(title="A1", body="B1", user_id=user.id); await p1.save()
+        p2 = post_class(title="A2", body="B2", user_id=user.id); await p2.save()
+
+        results = await user.posts()
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_async_has_many_empty(self, async_user_post_comment_classes):
+        user_class, post_class, comment_class = async_user_post_comment_classes
+        user = user_class(name="AsyncCarol"); await user.save()
+
+        results = await user.posts()
+        assert results == []
+
+
+
+    @pytest.mark.asyncio
+    async def test_async_cache_hit(self, async_user_post_comment_classes):
+        user_class, post_class, comment_class = async_user_post_comment_classes
+        user = user_class(name="AsyncEve"); await user.save()
+        p = post_class(title="Cached", body="B", user_id=user.id); await p.save()
+
+        r1 = await user.posts()
+        r2 = await user.posts()
+        assert len(r1) == 1
+        assert len(r2) == 1
+
+    @pytest.mark.asyncio
+    async def test_async_batch_load_empty_records(self, async_user_post_comment_classes):
+        """AsyncRelationDescriptor.batch_load with empty records."""
+        user_class, post_class, comment_class = async_user_post_comment_classes
+        desc = user_class.get_relation("posts")
+        result = await desc.batch_load([], None)
+        assert result == {}
+
+
+# ==============================================================================
+# Async _create_query_method
+# ==============================================================================
+
+class TestAsyncCreateQueryMethod:
+    """Cover async _create_query_method."""
+
+    @pytest.mark.asyncio
+    async def test_async_belongs_to_query(self, async_user_post_comment_classes):
+        user_class, post_class, comment_class = async_user_post_comment_classes
+        user = user_class(name="Alice"); await user.save()
+        post = post_class(title="P", body="B", user_id=user.id); await post.save()
+
+        query = post.user_query()
+        results = await query.all()
+        assert len(results) == 1
+        assert results[0].id == user.id
+
+    @pytest.mark.asyncio
+    async def test_async_has_many_query(self, async_user_post_comment_classes):
+        user_class, post_class, comment_class = async_user_post_comment_classes
+        user = user_class(name="Bob"); await user.save()
+        p1 = post_class(title="A", body="B1", user_id=user.id); await p1.save()
+        p2 = post_class(title="B", body="B2", user_id=user.id); await p2.save()
+
+        query = user.posts_query()
+        results = await query.all()
+        assert len(results) == 2
+
+
+

--- a/tests/rhosocial/activerecord_test/feature/relation/test_integration.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_integration.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_integration.py
+"""
+Bridge file for integration tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_integration import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_integration_async.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_integration_async.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_integration_async.py
+"""
+Bridge file for async integration tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_integration_async import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_modifier_behavior.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_modifier_behavior.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_modifier_behavior.py
+"""
+Bridge file for modifier behavior tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_modifier_behavior import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_modifier_behavior_async.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_modifier_behavior_async.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_modifier_behavior_async.py
+"""
+Bridge file for async modifier behavior tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_modifier_behavior_async import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_modifier_warning.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_modifier_warning.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_modifier_warning.py
+"""
+Bridge file for modifier warning tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_modifier_warning import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_modifier_warning_async.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_modifier_warning_async.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_modifier_warning_async.py
+"""
+Bridge file for async modifier warning tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_modifier_warning_async import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_path_validation.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_path_validation.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_path_validation.py
+"""
+Bridge file for path validation tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_path_validation import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_path_validation_async.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_path_validation_async.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_path_validation_async.py
+"""
+Bridge file for async path validation tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_path_validation_async import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_redis_cache.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_redis_cache.py
@@ -10,6 +10,12 @@ Use ``pytest -m redis`` to include these tests.
 import pytest
 import time
 
+pytest.skip(
+    "Redis cache is not introduced in this release; "
+    "source is kept for follow-up external cache design.",
+    allow_module_level=True,
+)
+
 from rhosocial.activerecord.relation.cache import CacheConfig, InstanceCache
 from rhosocial.activerecord.relation.cache_backends import (
     RedisCache,

--- a/tests/rhosocial/activerecord_test/feature/relation/test_redis_cache.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_redis_cache.py
@@ -7,7 +7,6 @@ If unavailable, Redis-dependent tests are skipped.
 
 Use ``pytest -m redis`` to include these tests.
 """
-import pickle
 import pytest
 import time
 
@@ -151,10 +150,12 @@ class TestRedisCacheBasic:
 
 
 class UpperSerializer(CacheSerializer):
-    """A serializer that uppercases string values before standard pickle."""
-    @staticmethod
-    def serialize(value):
-        return CacheSerializer.serialize(value.upper())
+    """A serializer that uppercases string values before pickle."""
+    def __init__(self):
+        super().__init__(format="pickle")
+
+    def serialize(self, value):
+        return super().serialize(value.upper())
 
 
 class TestRedisCacheSerialization:
@@ -184,13 +185,14 @@ class TestRedisCacheOrigin:
         assert any("origin=test-host" in msg for msg in caplog.messages)
 
     def test_origin_default_off(self, redis_cache, config, redis_client):
-        """record_origin=False stores raw pickled bytes, not JSON wrapper."""
+        """record_origin=False stores raw serialized bytes, not JSON wrapper."""
+        import json
         inst = _DummyModel(id=1)
         redis_cache.set(inst, "items", "plain", config)
         key = redis_cache._make_key(inst, "items")
         raw = redis_client.get(key)
         assert isinstance(raw, bytes)
-        assert pickle.loads(raw) == "plain"
+        assert json.loads(raw) == "plain"
 
 
 class TestRedisInMemorySwitch:

--- a/tests/rhosocial/activerecord_test/feature/relation/test_redis_cache.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_redis_cache.py
@@ -1,0 +1,267 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_redis_cache.py
+"""
+Tests for RedisCache backend.
+
+Requires a running Redis instance at localhost:16379 with password "ardev".
+If unavailable, Redis-dependent tests are skipped.
+
+Use ``pytest -m redis`` to include these tests.
+"""
+import pickle
+import pytest
+import time
+
+from rhosocial.activerecord.relation.cache import CacheConfig, InstanceCache
+from rhosocial.activerecord.relation.cache_backends import (
+    RedisCache,
+    RedisConfig,
+    CacheSerializer,
+    InMemoryCache,
+)
+
+pytestmark = pytest.mark.redis
+
+
+class _DummyModel:
+    """Minimal model stub for cache key unit tests."""
+    primary_key_name = "id"
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def primary_key(self):
+        return self.primary_key_name
+
+
+class _DummyNoPK(_DummyModel):
+    primary_key_name = "id"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # deliberately not setting "id"
+
+
+@pytest.fixture(scope="module")
+def redis_client():
+    redis = pytest.importorskip("redis")
+    config = RedisConfig.from_env()
+    try:
+        client = redis.Redis(
+            host=config.host, port=config.port, password=config.password or None,
+            db=config.db, socket_connect_timeout=config.socket_connect_timeout,
+        )
+        client.ping()
+        yield client
+        client.flushdb()
+    except Exception as e:
+        pytest.skip(f"Redis not available ({e})")
+        yield None
+    finally:
+        try:
+            client.close()
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def redis_cache(redis_client):
+    """Create RedisCache with a clean DB per test."""
+    redis_client.flushdb()
+    return RedisCache(redis_client, prefix="test:cache:")
+
+
+@pytest.fixture
+def config():
+    return CacheConfig(enabled=True, ttl=300)
+
+
+class TestRedisCacheKey:
+    """Key generation and format."""
+
+    def test_key_format(self, redis_cache, config):
+        """Key follows {prefix}ModelName:pk:relation."""
+        instance = _DummyModel(id=42)
+        key = redis_cache._make_key(instance, "posts")
+        assert key == "test:cache:_DummyModel:42:posts"
+
+    def test_missing_pk_raises(self, redis_cache):
+        """Instance without PK raises ValueError."""
+        instance = _DummyNoPK()
+        with pytest.raises(ValueError, match="no primary key"):
+            redis_cache._make_key(instance, "posts")
+
+
+class TestRedisCacheBasic:
+    """Basic get/set/delete operations."""
+
+    def test_set_and_get(self, redis_cache, config, redis_client):
+        inst = _DummyModel(id=1)
+        value = ["item1", "item2"]
+
+        redis_cache.set(inst, "items", value, config)
+        key = redis_cache._make_key(inst, "items")
+        assert redis_client.exists(key)
+
+        result = redis_cache.get(inst, "items", config)
+        assert result == value
+
+    def test_get_miss(self, redis_cache, config):
+        inst = _DummyModel(id=1)
+        result = redis_cache.get(inst, "items", config)
+        assert result is None
+
+    def test_delete(self, redis_cache, config, redis_client):
+        inst = _DummyModel(id=1)
+        redis_cache.set(inst, "items", "data", config)
+        key = redis_cache._make_key(inst, "items")
+        assert redis_client.exists(key)
+
+        redis_cache.delete(inst, "items")
+        assert not redis_client.exists(key)
+        assert redis_cache.get(inst, "items", config) is None
+
+    def test_disabled_config_skips(self, redis_cache):
+        inst = _DummyModel(id=1)
+        disabled = CacheConfig(enabled=False)
+
+        redis_cache.set(inst, "items", "data", disabled)
+        assert redis_cache.get(inst, "items", disabled) is None
+
+        redis_cache.delete(inst, "items", disabled)
+
+    def test_ttl_expiry(self, redis_cache, config, redis_client):
+        inst = _DummyModel(id=1)
+        ttl_config = CacheConfig(enabled=True, ttl=1)
+
+        redis_cache.set(inst, "items", "expirable", ttl_config)
+        assert redis_cache.get(inst, "items", ttl_config) == "expirable"
+
+        time.sleep(1.5)
+        assert redis_cache.get(inst, "items", ttl_config) is None
+
+    def test_no_ttl_persists(self, redis_cache, redis_client):
+        inst = _DummyModel(id=1)
+        no_ttl = CacheConfig(enabled=True, ttl=None)
+
+        redis_cache.set(inst, "items", "persistent", no_ttl)
+        key = redis_cache._make_key(inst, "items")
+        ttl = redis_client.ttl(key)
+        assert ttl == -1  # no expiry
+
+
+class UpperSerializer(CacheSerializer):
+    """A serializer that uppercases string values before standard pickle."""
+    @staticmethod
+    def serialize(value):
+        return CacheSerializer.serialize(value.upper())
+
+
+class TestRedisCacheSerialization:
+    """Custom serialization support."""
+
+    def test_custom_serializer(self, redis_cache, config, redis_client):
+        cache = RedisCache(redis_client, prefix="test:ser:", serializer=UpperSerializer())
+        inst = _DummyModel(id=1)
+
+        cache.set(inst, "name", "hello", config)
+        result = cache.get(inst, "name", config)
+        assert result == "HELLO"
+
+
+class TestRedisCacheOrigin:
+    """Origin metadata (observability)."""
+
+    def test_record_origin(self, redis_cache, config, redis_client, caplog):
+        caplog.set_level("DEBUG", logger="rhosocial.activerecord.relation.cache_backends.redis")
+        cache = RedisCache(redis_client, prefix="test:origin:", record_origin=True, origin_name="test-host")
+        inst = _DummyModel(id=1)
+
+        cache.set(inst, "items", "data", config)
+        result = cache.get(inst, "items", config)
+        assert result == "data"
+
+        assert any("origin=test-host" in msg for msg in caplog.messages)
+
+    def test_origin_default_off(self, redis_cache, config, redis_client):
+        """record_origin=False stores raw pickled bytes, not JSON wrapper."""
+        inst = _DummyModel(id=1)
+        redis_cache.set(inst, "items", "plain", config)
+        key = redis_cache._make_key(inst, "items")
+        raw = redis_client.get(key)
+        assert isinstance(raw, bytes)
+        assert pickle.loads(raw) == "plain"
+
+
+class TestRedisInMemorySwitch:
+    """Switching backends via InstanceCache.set_backend."""
+
+    def test_switch_to_redis_and_back(self, redis_cache):
+        inst = _DummyModel(id=1)
+        config = CacheConfig(enabled=True, ttl=300)
+
+        original = InstanceCache._backend
+        try:
+            InstanceCache.set_backend(redis_cache)
+            InstanceCache.set(inst, "data", "from-redis", config)
+            assert InstanceCache.get(inst, "data", config) == "from-redis"
+
+            InstanceCache.set_backend(InMemoryCache())
+            InstanceCache.set(inst, "data", "from-memory", config)
+            assert InstanceCache.get(inst, "data", config) == "from-memory"
+        finally:
+            InstanceCache.set_backend(original)
+
+    def test_after_switch_redis_persists(self, redis_client):
+        """Data set via RedisCache remains accessible to a fresh RedisCache instance."""
+        inst = _DummyModel(id=1)
+        config = CacheConfig(enabled=True, ttl=300)
+
+        redis_client.flushdb()
+        c1 = RedisCache(redis_client, prefix="test:switch:")
+        c1.set(inst, "items", "persisted", config)
+
+        c2 = RedisCache(redis_client, prefix="test:switch:")
+        assert c2.get(inst, "items", config) == "persisted"
+
+
+class TestRedisInconsistency:
+    """Stale/inconsistent data scenario (read-only)."""
+
+    def test_stale_data_returned(self, redis_cache, config, redis_client):
+        """If data is changed in DB but cache is not invalidated, stale value is returned."""
+        inst = _DummyModel(id=1)
+        redis_cache.set(inst, "count", 10, config)
+
+        # Simulate DB update without cache invalidation
+        redis_cache.set(inst, "count", 99, config)
+
+        assert redis_cache.get(inst, "count", config) == 99
+
+
+class TestRedisInstanceInvalidation:
+    """invalidate_instance clears all cached relations for an instance."""
+
+    def test_invalidate_instance(self, redis_cache, config, redis_client):
+        inst = _DummyModel(id=1)
+        redis_cache.set(inst, "posts", ["p1", "p2"], config)
+        redis_cache.set(inst, "comments", ["c1"], config)
+
+        assert redis_cache.get(inst, "posts", config) is not None
+        assert redis_cache.get(inst, "comments", config) is not None
+
+        redis_cache.invalidate_instance(inst)
+
+        assert redis_cache.get(inst, "posts", config) is None
+        assert redis_cache.get(inst, "comments", config) is None
+
+    def test_invalidate_instance_other_untouched(self, redis_cache, config, redis_client):
+        inst1 = _DummyModel(id=1)
+        inst2 = _DummyModel(id=2)
+
+        redis_cache.set(inst1, "data", "a", config)
+        redis_cache.set(inst2, "data", "b", config)
+
+        redis_cache.invalidate_instance(inst1)
+        assert redis_cache.get(inst1, "data", config) is None
+        assert redis_cache.get(inst2, "data", config) == "b"

--- a/tests/rhosocial/activerecord_test/feature/relation/test_relation_modifier_cache.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_relation_modifier_cache.py
@@ -1,215 +1,282 @@
 # tests/rhosocial/activerecord_test/feature/relation/test_relation_modifier_cache.py
 """
-Tests for relation caching behavior with query modifiers.
+Database-backed relation cache tests using real SQLite with SQL query counting.
 
-These tests specifically cover the interaction between with_() modifiers
-and the relation cache, which is a key feature of python-activerecord.
+Verifies that the instance-level cache (InstanceCache) correctly prevents
+redundant SQL queries on repeated relation access, and that cache invalidation
+(for delete, TTL expiry, disabled cache, etc.) re-queries the database.
 """
 import pytest
-from typing import ClassVar, Any, Optional, List, Dict
+import time
+from typing import ClassVar, Dict, Any, List, Tuple, Optional
 
 from pydantic import BaseModel
 
-from rhosocial.activerecord.relation.cache import CacheConfig, InstanceCache
 from rhosocial.activerecord.relation.base import RelationManagementMixin
+from rhosocial.activerecord.relation.cache import CacheConfig
 from rhosocial.activerecord.relation.descriptors import HasMany, BelongsTo
 
 
-class MockLoaderWithCounter:
-    """Loader that tracks how many times it was called."""
-    def __init__(self):
-        self.load_count = 0
-        self.batch_load_count = 0
+class QueryCounter:
+    """Wraps backend fetch methods to count executed SQL queries."""
 
-    def load(self, instance: Any) -> Optional[List[Any]]:
-        self.load_count += 1
-        return [{"id": 1, "name": f"Item {self.load_count}"}]
+    def __init__(self, backends: Dict[str, Any]):
+        self.count = 0
+        self._originals: Dict[str, Tuple] = {}
+        for name, backend in backends.items():
+            self._originals[name] = (backend.fetch_all, backend.fetch_one)
+            backend.fetch_all = self._wrap(backend.fetch_all)
+            backend.fetch_one = self._wrap(backend.fetch_one)
 
-    def batch_load(self, instances: List[Any], base_query: Any) -> Dict[int, Any]:
-        self.batch_load_count += 1
-        return {id(inst): [{"id": 1, "name": f"Item {self.batch_load_count}"}] for inst in instances}
+    def _wrap(self, original):
+        def wrapper(sql, params, column_adapters=None):
+            self.count += 1
+            return original(sql, params, column_adapters)
+        return wrapper
 
-
-class Author(RelationManagementMixin, BaseModel):
-    id: int
-    name: str
-    books: ClassVar[HasMany["Book"]] = HasMany(
-        foreign_key="author_id",
-        inverse_of="author"
-    )
+    def reset(self):
+        self.count = 0
 
 
-class Book(RelationManagementMixin, BaseModel):
-    id: int
-    title: str
-    author_id: int
-    author: ClassVar[BelongsTo["Author"]] = BelongsTo(
-        foreign_key="author_id",
-        inverse_of="books"
-    )
+@pytest.fixture
+def cache_test_env(user_post_comment_classes):
+    """Set up test data and wrap backends with a query counter.
+
+    Returns (user_class, post_class, comment_class, user, post, counter).
+    """
+    user_class, post_class, comment_class = user_post_comment_classes
+
+    backends = {}
+    for cls in (user_class, post_class, comment_class):
+        try:
+            backends[cls.__name__] = cls.backend()
+        except Exception:
+            pass
+    counter = QueryCounter(backends)
+
+    user = user_class(name="Cache User", email="cache@example.com")
+    user.save()
+    post = post_class(title="Cache Post", body="Content", user_id=user.id)
+    post.save()
+
+    counter.reset()
+    yield user_class, post_class, comment_class, user, post, counter
+
+    for name, backend in backends.items():
+        orig_all, orig_one = counter._originals.get(name, (None, None))
+        if orig_all is not None:
+            backend.fetch_all = orig_all
+        if orig_one is not None:
+            backend.fetch_one = orig_one
 
 
-class TestRelationModifierCache:
-    """Tests for relation cache behavior with query modifiers."""
+class TestRelationCacheFirstAccess:
+    """First relation access should query the database."""
 
-    @pytest.fixture
-    def author_instance(self):
-        return Author(id=1, name="Test Author")
+    def test_first_access_queries_db(self, cache_test_env):
+        """First access to a relation executes SQL."""
+        _, _, _, user, _, counter = cache_test_env
+        results = user.posts()
+        assert len(results) == 1
+        assert counter.count > 0
 
-    @pytest.fixture
-    def book_instance(self):
-        return Book(id=1, title="Test Book", author_id=1)
+    def test_first_access_has_many_empty(self, cache_test_env):
+        """HasMany with no related records still executes a query."""
+        user_class, _, _, _, _, counter = cache_test_env
+        user2 = user_class(name="Empty User", email="empty@example.com")
+        user2.save()
+        counter.reset()
 
-    def test_first_access_loads_from_loader(self, author_instance):
-        """Test that first access to relation loads from loader."""
-        loader = MockLoaderWithCounter()
-        relation = author_instance.get_relation("books")
-        relation._loader = loader
+        results = user2.posts()
+        assert results == []
+        assert counter.count > 0
 
-        result = relation._load_relation(author_instance)
-
-        assert loader.load_count == 1
+    def test_first_access_belongs_to(self, cache_test_env):
+        """BelongsTo first access executes SQL."""
+        _, _, _, _, post, counter = cache_test_env
+        result = post.user()
         assert result is not None
+        assert counter.count > 0
 
-    def test_second_access_uses_cache(self, author_instance):
-        """Test that second access uses cached value."""
-        loader = MockLoaderWithCounter()
-        relation = author_instance.get_relation("books")
-        relation._loader = loader
 
-        result1 = relation._load_relation(author_instance)
-        result2 = relation._load_relation(author_instance)
+class TestRelationCacheSecondAccess:
+    """Second (and subsequent) accesses should hit the cache."""
 
-        assert loader.load_count == 1
-        assert result1 == result2
+    def test_second_access_has_many_uses_cache(self, cache_test_env):
+        """Second HasMany access uses cache (no SQL)."""
+        _, _, _, user, _, counter = cache_test_env
+        r1 = user.posts()
+        q1 = counter.count
 
-    def test_cache_cleared_on_delete(self, author_instance):
-        """Test that cache is cleared when relation is deleted."""
-        loader = MockLoaderWithCounter()
-        relation = author_instance.get_relation("books")
-        relation._loader = loader
+        r2 = user.posts()
+        assert counter.count == q1
+        assert len(r1) == len(r2)
 
-        result1 = relation._load_relation(author_instance)
-        assert loader.load_count == 1
+    def test_second_access_belongs_to_uses_cache(self, cache_test_env):
+        """Second BelongsTo access uses cache (no SQL)."""
+        _, _, _, _, post, counter = cache_test_env
+        r1 = post.user()
+        q1 = counter.count
 
-        relation.__delete__(author_instance)
+        r2 = post.user()
+        assert counter.count == q1
+        assert r1.id == r2.id
 
-        result2 = relation._load_relation(author_instance)
-        assert loader.load_count == 2
+    def test_multiple_accesses_no_extra_queries(self, cache_test_env):
+        """Three accesses cause only one SQL query total."""
+        _, _, _, user, _, counter = cache_test_env
+        user.posts()
+        q1 = counter.count
 
-    def test_clear_relation_cache_method(self, author_instance):
-        """Test clear_relation_cache method."""
-        loader = MockLoaderWithCounter()
-        relation = author_instance.get_relation("books")
-        relation._loader = loader
+        for _ in range(5):
+            user.posts()
 
-        relation._load_relation(author_instance)
-        assert loader.load_count == 1
+        assert counter.count == q1
 
-        author_instance.clear_relation_cache("books")
 
-        relation._load_relation(author_instance)
-        assert loader.load_count == 2
+class TestRelationCacheInvalidation:
+    """Cache invalidation scenarios (delete, clear, TTL, disabled)."""
 
-    def test_clear_all_relations_cache(self, author_instance):
-        """Test clearing all relation caches."""
-        loader = MockLoaderWithCounter()
-        relation = author_instance.get_relation("books")
-        relation._loader = loader
+    def test_cache_cleared_on_delete(self, cache_test_env):
+        """__delete__ clears cache; next access re-queries."""
+        user_class, _, _, user, _, counter = cache_test_env
+        user.posts()
+        counter.reset()
 
-        relation._load_relation(author_instance)
-        assert loader.load_count == 1
+        desc = user_class.get_relation("posts")
+        desc.__delete__(user)
 
-        author_instance.clear_relation_cache()
+        results = user.posts()
+        assert len(results) == 1
+        assert counter.count > 0
 
-        relation._load_relation(author_instance)
-        assert loader.load_count == 2
+    def test_clear_relation_cache_method(self, cache_test_env):
+        """clear_relation_cache(name) forces a new query."""
+        _, _, _, user, _, counter = cache_test_env
+        user.posts()
+        counter.reset()
 
-    def test_cache_isolation_between_instances(self):
-        """Test that cache is isolated between different instances."""
-        author1 = Author(id=1, name="Author 1")
-        author2 = Author(id=2, name="Author 2")
+        user.clear_relation_cache("posts")
 
-        loader = MockLoaderWithCounter()
-        relation1 = author1.get_relation("books")
-        relation2 = author2.get_relation("books")
-        relation1._loader = loader
-        relation2._loader = loader
+        results = user.posts()
+        assert len(results) == 1
+        assert counter.count > 0
 
-        result1 = relation1._load_relation(author1)
-        result2 = relation2._load_relation(author2)
+    def test_clear_all_relations_cache(self, cache_test_env):
+        """clear_relation_cache() without args clears all caches."""
+        _, _, _, user, _, counter = cache_test_env
+        user.posts()
+        counter.reset()
 
-        assert loader.load_count == 2
-        assert result1 is not None
-        assert result2 is not None
+        user.clear_relation_cache()
 
-    def test_cache_with_custom_config(self, author_instance):
-        """Test caching with custom CacheConfig."""
-        config = CacheConfig(ttl=1, enabled=True)
-        relation = author_instance.get_relation("books")
-        relation._cache_config = config
+        results = user.posts()
+        assert len(results) == 1
+        assert counter.count > 0
 
-        loader = MockLoaderWithCounter()
-        relation._loader = loader
+    def test_cache_with_disabled_config(self, cache_test_env):
+        """disabled cache executes a query on every access."""
+        user_class, _, _, user, _, counter = cache_test_env
 
-        result1 = relation._load_relation(author_instance)
-        result2 = relation._load_relation(author_instance)
+        desc = user_class.get_relation("posts")
+        orig_config = desc._cache_config
+        desc._cache_config = CacheConfig(enabled=False)
 
-        assert loader.load_count == 1
+        try:
+            user.posts()
+            counter.reset()
 
-    def test_cache_disabled_config(self, author_instance):
-        """Test that caching is disabled with enabled=False."""
-        config = CacheConfig(enabled=False)
-        relation = author_instance.get_relation("books")
-        relation._cache_config = config
+            user.posts()
+            q1 = counter.count
 
-        loader = MockLoaderWithCounter()
-        relation._loader = loader
+            user.posts()
+            assert counter.count > q1
+        finally:
+            desc._cache_config = orig_config
 
-        result1 = relation._load_relation(author_instance)
-        result2 = relation._load_relation(author_instance)
+    def test_cache_with_expired_ttl(self, cache_test_env):
+        """Expired TTL causes a new query."""
+        user_class, _, _, user, _, counter = cache_test_env
 
-        assert loader.load_count == 2
+        desc = user_class.get_relation("posts")
+        orig_config = desc._cache_config
+        desc._cache_config = CacheConfig(ttl=1)
 
-    def test_cache_with_expired_ttl(self, author_instance):
-        """Test cache expiration after TTL."""
-        config = CacheConfig(ttl=1)
-        relation = author_instance.get_relation("books")
-        relation._cache_config = config
+        try:
+            user.posts()
+            counter.reset()
 
-        import time
-        loader = MockLoaderWithCounter()
-        relation._loader = loader
+            time.sleep(1.1)
 
-        result1 = relation._load_relation(author_instance)
-        assert loader.load_count == 1
+            results = user.posts()
+            assert len(results) == 1
+            assert counter.count > 0
+        finally:
+            desc._cache_config = orig_config
 
-        time.sleep(1.1)
 
-        result2 = relation._load_relation(author_instance)
-        assert loader.load_count == 2
+class TestRelationCacheIsolation:
+    """Cache isolation between instances and relations."""
 
-    def test_different_relations_independent_cache(self, book_instance):
-        """Test that different relations have independent caches."""
-        loader = MockLoaderWithCounter()
-        book_loader = MockLoaderWithCounter()
+    def test_cache_isolation_between_instances(self, cache_test_env):
+        """Different instances have independent caches."""
+        user_class, post_class, _, user, _, counter = cache_test_env
 
-        author_relation = book_instance.get_relation("author")
-        author_relation._loader = book_loader
+        user2 = user_class(name="Second User", email="u2@example.com")
+        user2.save()
+        post2 = post_class(title="Second Post", body="Content", user_id=user2.id)
+        post2.save()
 
-        result1 = author_relation._load_relation(book_instance)
-        assert book_loader.load_count == 1
+        user.posts()
+        user2.posts()
+        counter.reset()
 
-        result2 = author_relation._load_relation(book_instance)
-        assert book_loader.load_count == 1
+        r1 = user.posts()
+        r2 = user2.posts()
+        assert counter.count == 0
+        assert len(r1) == 1
+        assert len(r2) == 1
 
-    def test_loading_without_loader(self, author_instance):
-        """Test loading when no loader is set."""
-        relation = author_instance.get_relation("books")
-        relation._loader = None
+    def test_different_relations_independent_cache(self, cache_test_env):
+        """Different relation types on the same instance cache independently."""
+        _, _, _, user, post, counter = cache_test_env
 
-        result = relation._load_relation(author_instance)
-        assert result is None
+        _ = post.user()
+        counter.reset()
+
+        r2 = post.user()
+        assert counter.count == 0  # BelongsTo cached
+
+        _ = user.posts()
+        assert counter.count > 0  # HasMany not cached on post instance
+
+
+class TestRelationCacheBulk:
+    """Bulk / edge-case scenarios."""
+
+    def test_reload_same_data_idempotent(self, cache_test_env):
+        """Adding more related data after caching is not visible until cache cleared."""
+        user_class, post_class, _, user, _, counter = cache_test_env
+
+        user.posts()
+        counter.reset()
+
+        extra = post_class(title="Extra Post", body="Extra", user_id=user.id)
+        extra.save()
+
+        results = user.posts()
+        assert len(results) == 1
+        assert counter.count == 0  # Cache returns stale data
+
+        user.clear_relation_cache("posts")
+        counter.reset()
+
+        results = user.posts()
+        assert len(results) == 2
+        assert counter.count > 0
+
+
+# ── Non-DB protocol tests (kept from original mock-based file) ─────
 
 
 class TestRelationDescriptorProtocol:
@@ -217,35 +284,59 @@ class TestRelationDescriptorProtocol:
 
     def test_get_descriptor_from_class(self):
         """Test accessing descriptor from class returns descriptor itself."""
-        relation = Author.get_relation("books")
+        class _Author(RelationManagementMixin, BaseModel):
+            id: int
+            books: ClassVar[HasMany["_Book"]] = HasMany(foreign_key="author_id")
+
+        class _Book(RelationManagementMixin, BaseModel):
+            id: int
+            author_id: int
+            author: ClassVar[BelongsTo["_Author"]] = BelongsTo(foreign_key="author_id")
+
+        relation = _Author.get_relation("books")
         assert isinstance(relation, HasMany)
         assert relation.foreign_key == "author_id"
 
     def test_get_descriptor_from_instance_returns_method(self):
         """Test accessing descriptor from instance returns bound method."""
-        author = Author(id=1, name="Test")
+        class _Author(RelationManagementMixin, BaseModel):
+            id: int
+            books: ClassVar[HasMany["_Book"]] = HasMany(foreign_key="author_id")
 
+        class _Book(RelationManagementMixin, BaseModel):
+            id: int
+            author_id: int
+
+        author = _Author(id=1)
         books_relation = author.books
         assert callable(books_relation)
 
     def test_set_name_callback(self):
         """Test that __set_name__ is called on descriptor assignment."""
-        class OtherItem(RelationManagementMixin, BaseModel):
+
+        class _OtherItem(RelationManagementMixin, BaseModel):
             id: int
             test_id: int
 
-        class TestModelForName(RelationManagementMixin, BaseModel):
+        class _TestModel(RelationManagementMixin, BaseModel):
             id: int
-            items: ClassVar[HasMany["OtherItem"]] = HasMany(
-                foreign_key="test_id",
-                inverse_of="test"
+            items: ClassVar[HasMany["_OtherItem"]] = HasMany(
+                foreign_key="test_id", inverse_of="test"
             )
 
-        relation = TestModelForName.get_relation("items")
+        relation = _TestModel.get_relation("items")
         assert relation.name == "items"
-        assert relation._owner == TestModelForName
+        assert relation._owner == _TestModel
 
     def test_query_method_created(self):
         """Test that query method is created for relation."""
-        assert hasattr(Author, "books_query")
-        assert callable(Author.books_query)
+        class _Author(RelationManagementMixin, BaseModel):
+            id: int
+            books: ClassVar[HasMany["_Book"]] = HasMany(foreign_key="author_id")
+
+        class _Book(RelationManagementMixin, BaseModel):
+            id: int
+            author_id: int
+
+        assert hasattr(_Author, "books_query")
+        assert callable(_Author.books_query)

--- a/tests/rhosocial/activerecord_test/feature/relation/test_relation_validation.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_relation_validation.py
@@ -30,7 +30,9 @@ class MockQueryBase(IQuery):
         self.join_clauses = []
         self.limit_count = None
         self.offset_count = None
-        self.select_columns = None
+        from rhosocial.activerecord.backend.expression import WildcardExpression
+        from rhosocial.activerecord.backend.impl.sqlite.dialect import SQLiteDialect
+        self.select_columns = [WildcardExpression(SQLiteDialect())]
         self._explain_enabled = False
         self._explain_options = None
 

--- a/tests/rhosocial/activerecord_test/feature/relation/test_with_method.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_with_method.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_with_method.py
+"""
+Bridge file for with_() method tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_with_method import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_with_method_async.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_with_method_async.py
@@ -1,0 +1,5 @@
+# tests/rhosocial/activerecord_test/feature/relation/test_with_method_async.py
+"""
+Bridge file for async with_() method tests from the testsuite.
+"""
+from rhosocial.activerecord.testsuite.feature.relation.test_with_method_async import *  # noqa: F401,F403

--- a/tests/rhosocial/activerecord_test/feature/relation/test_with_modifier.py
+++ b/tests/rhosocial/activerecord_test/feature/relation/test_with_modifier.py
@@ -28,7 +28,9 @@ class MockQueryBase(IQuery):
         self.join_clauses = []
         self.limit_count = None
         self.offset_count = None
-        self.select_columns = None
+        from rhosocial.activerecord.backend.expression import WildcardExpression
+        from rhosocial.activerecord.backend.impl.sqlite.dialect import SQLiteDialect
+        self.select_columns = [WildcardExpression(SQLiteDialect())]
         self._explain_enabled = False
         self._explain_options = None
 


### PR DESCRIPTION
## Description

Comprehensive fixes and improvements for the relation module.

### Relation Module Fixes
- Prohibit sync/async descriptor mixing with TypeError guards
- Fix InstanceCache.delete call path and add empty-records guard to batch_load
- Remove unreachable `_query` branch from `_create_relation_method`
- Avoid stale cached ForwardRef state from `typing_extensions.evaluate_forward_ref`
- Add descriptor, loader, cache, boundary, and integration coverage

### Cache Scope for This Branch
- Keep relation cache abstraction and existing `InMemoryCache` behavior
- Keep benchmark scenarios limited to `no_cache` and `in_memory`
- Do not introduce RedisCache, CacheSerializer, msgpack, pickle/JSON serializer changes, CacheResult metadata, or origin tracking in this branch
- Keep external/distributed cache support as a follow-up design target

### Test Quality Improvements
- Replace mock cache tests with real SQLite + SQL query counting
- Add boundary coverage and JSON capability guards
- Add relation benchmark coverage for NoCache and InMemory scenarios

## Type of change

- [x] `fix`: Bug fixes in relation module
- [x] `test`: Test improvements
- [ ] `feat`: New external cache features
- [ ] `refactor`: Cache serializer changes
- [x] `ci`: CI/benchmark improvements
- [x] `docs`: Cache scope documentation

## Breaking Change

- [x] No breaking changes

External cache backends, RedisCache, CacheSerializer, CacheResult metadata, and msgpack support are intentionally not part of this branch.

## Testing

- [x] `pytest tests/rhosocial/activerecord_test/feature/relation/test_descriptor_db_coverage.py tests/rhosocial/activerecord_test/feature/relation/test_relation_modifier_cache.py -q`
- [x] `pytest tests/benchmark/relation/test_cache_comparison.py -m benchmark_relation -q`
- [x] `pytest tests/rhosocial/activerecord_test/feature/relation -q`