### PR TITLE
feat(query): add expression-level COLLATE support

### DIFF
--- a/changelog.d/97.added.md
+++ b/changelog.d/97.added.md
@@ -1,0 +1,1 @@
+Added expression-level `COLLATE` support for SQL value expressions, with dialect-level collation validation and SQLite formatting support.

--- a/src/rhosocial/activerecord/backend/dialect/mixins.py
+++ b/src/rhosocial/activerecord/backend/dialect/mixins.py
@@ -27,7 +27,7 @@ class CollationMixin:
         """Validate a collation expression and return its SQL representation."""
         raise UnsupportedFeatureError(self.name, "COLLATE collation validation")
 
-    def format_collate_expression(self, expr: Any) -> Tuple[str, tuple]:
+    def format_collate_expression(self, expr: "CollateExpression") -> Tuple[str, tuple]:
         """Format expression-level COLLATE."""
         if not self.supports_collate_expression():
             raise UnsupportedFeatureError(self.name, "COLLATE expression")

--- a/src/rhosocial/activerecord/backend/dialect/mixins.py
+++ b/src/rhosocial/activerecord/backend/dialect/mixins.py
@@ -23,7 +23,7 @@ class CollationMixin:
         """Whether expression-level COLLATE is supported."""
         return False
 
-    def validate_collation_name(self, collation: Any) -> str:
+    def validate_collation_name(self, collation: "CollationName") -> str:
         """Validate a collation name and return its SQL representation."""
         raise UnsupportedFeatureError(self.name, "COLLATE collation validation")
 
@@ -37,6 +37,7 @@ class CollationMixin:
 
 
 if TYPE_CHECKING:  # pragma: no cover
+    from ..expression.collation import CollationName
     from ..expression.advanced_functions import (
         OrderedSetAggregation,
         WindowFunctionCall,

--- a/src/rhosocial/activerecord/backend/dialect/mixins.py
+++ b/src/rhosocial/activerecord/backend/dialect/mixins.py
@@ -16,6 +16,29 @@ from ..expression import bases
 from ..expression.bases import ToSQLProtocol
 from ..expression.statements import ReturningClause
 
+class CollationMixin:
+    """Mixin for expression-level COLLATE support."""
+
+    def supports_collate_expression(self) -> bool:
+        """Whether expression-level COLLATE is supported."""
+        return False
+
+    def format_collation_name(self, collation: Any) -> str:
+        """Format a collation name for use in COLLATE clauses."""
+        if getattr(collation, "keyword", None):
+            return collation.keyword
+        if getattr(collation, "schema", None):
+            return f"{self.format_identifier(collation.schema)}.{self.format_identifier(collation.name)}"
+        return self.format_identifier(collation.name)
+
+    def format_collate_expression(self, expr: Any) -> Tuple[str, tuple]:
+        """Format expression-level COLLATE."""
+        if not self.supports_collate_expression():
+            raise UnsupportedFeatureError(self.name, "COLLATE expression")
+        expression_sql, params = expr.expression.to_sql()
+        return f"{expression_sql} COLLATE {self.format_collation_name(expr.collation)}", params
+
+
 if TYPE_CHECKING:  # pragma: no cover
     from ..expression.advanced_functions import (
         OrderedSetAggregation,

--- a/src/rhosocial/activerecord/backend/dialect/mixins.py
+++ b/src/rhosocial/activerecord/backend/dialect/mixins.py
@@ -23,20 +23,17 @@ class CollationMixin:
         """Whether expression-level COLLATE is supported."""
         return False
 
-    def format_collation_name(self, collation: Any) -> str:
-        """Format a collation name for use in COLLATE clauses."""
-        if getattr(collation, "keyword", None):
-            return collation.keyword
-        if getattr(collation, "schema", None):
-            return f"{self.format_identifier(collation.schema)}.{self.format_identifier(collation.name)}"
-        return self.format_identifier(collation.name)
+    def validate_collation_name(self, collation: Any) -> str:
+        """Validate a collation name and return its SQL representation."""
+        raise UnsupportedFeatureError(self.name, "COLLATE collation validation")
 
     def format_collate_expression(self, expr: Any) -> Tuple[str, tuple]:
         """Format expression-level COLLATE."""
         if not self.supports_collate_expression():
             raise UnsupportedFeatureError(self.name, "COLLATE expression")
         expression_sql, params = expr.expression.to_sql()
-        return f"{expression_sql} COLLATE {self.format_collation_name(expr.collation)}", params
+        collation_sql = self.validate_collation_name(expr.collation)
+        return f"{expression_sql} COLLATE {collation_sql}", params
 
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/src/rhosocial/activerecord/backend/dialect/mixins.py
+++ b/src/rhosocial/activerecord/backend/dialect/mixins.py
@@ -23,8 +23,8 @@ class CollationMixin:
         """Whether expression-level COLLATE is supported."""
         return False
 
-    def validate_collation_name(self, collation: "CollationName") -> str:
-        """Validate a collation name and return its SQL representation."""
+    def validate_collation_name(self, expr: "CollateExpression") -> str:
+        """Validate a collation expression and return its SQL representation."""
         raise UnsupportedFeatureError(self.name, "COLLATE collation validation")
 
     def format_collate_expression(self, expr: Any) -> Tuple[str, tuple]:
@@ -32,12 +32,12 @@ class CollationMixin:
         if not self.supports_collate_expression():
             raise UnsupportedFeatureError(self.name, "COLLATE expression")
         expression_sql, params = expr.expression.to_sql()
-        collation_sql = self.validate_collation_name(expr.collation)
+        collation_sql = self.validate_collation_name(expr)
         return f"{expression_sql} COLLATE {collation_sql}", params
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ..expression.collation import CollationName
+    from ..expression.collation import CollateExpression
     from ..expression.advanced_functions import (
         OrderedSetAggregation,
         WindowFunctionCall,

--- a/src/rhosocial/activerecord/backend/dialect/protocols.py
+++ b/src/rhosocial/activerecord/backend/dialect/protocols.py
@@ -82,8 +82,8 @@ class CollationSupport(Protocol):
         """Whether expression-level COLLATE is supported."""
         ...  # pragma: no cover
 
-    def format_collation_name(self, collation: Any) -> str:
-        """Format a collation name for use in COLLATE clauses."""
+    def validate_collation_name(self, collation: Any) -> str:
+        """Validate a collation name and return its SQL representation."""
         ...  # pragma: no cover
 
     def format_collate_expression(self, expr: Any) -> Tuple[str, tuple]:

--- a/src/rhosocial/activerecord/backend/dialect/protocols.py
+++ b/src/rhosocial/activerecord/backend/dialect/protocols.py
@@ -72,7 +72,7 @@ if TYPE_CHECKING:  # pragma: no cover
         TriggerListExpression,
         TriggerInfoExpression,
     )
-    from ..expression.collation import CollationName
+    from ..expression.collation import CollateExpression
 
 
 @runtime_checkable
@@ -83,8 +83,8 @@ class CollationSupport(Protocol):
         """Whether expression-level COLLATE is supported."""
         ...  # pragma: no cover
 
-    def validate_collation_name(self, collation: "CollationName") -> str:
-        """Validate a collation name and return its SQL representation."""
+    def validate_collation_name(self, expr: "CollateExpression") -> str:
+        """Validate a collation expression and return its SQL representation."""
         ...  # pragma: no cover
 
     def format_collate_expression(self, expr: Any) -> Tuple[str, tuple]:

--- a/src/rhosocial/activerecord/backend/dialect/protocols.py
+++ b/src/rhosocial/activerecord/backend/dialect/protocols.py
@@ -75,6 +75,23 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 @runtime_checkable
+class CollationSupport(Protocol):
+    """Protocol for expression-level COLLATE support."""
+
+    def supports_collate_expression(self) -> bool:
+        """Whether expression-level COLLATE is supported."""
+        ...  # pragma: no cover
+
+    def format_collation_name(self, collation: Any) -> str:
+        """Format a collation name for use in COLLATE clauses."""
+        ...  # pragma: no cover
+
+    def format_collate_expression(self, expr: Any) -> Tuple[str, tuple]:
+        """Format expression-level COLLATE."""
+        ...  # pragma: no cover
+
+
+@runtime_checkable
 class WindowFunctionSupport(Protocol):
     """Protocol for window function support."""
 

--- a/src/rhosocial/activerecord/backend/dialect/protocols.py
+++ b/src/rhosocial/activerecord/backend/dialect/protocols.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:  # pragma: no cover
         TriggerListExpression,
         TriggerInfoExpression,
     )
+    from ..expression.collation import CollationName
 
 
 @runtime_checkable
@@ -82,7 +83,7 @@ class CollationSupport(Protocol):
         """Whether expression-level COLLATE is supported."""
         ...  # pragma: no cover
 
-    def validate_collation_name(self, collation: Any) -> str:
+    def validate_collation_name(self, collation: "CollationName") -> str:
         """Validate a collation name and return its SQL representation."""
         ...  # pragma: no cover
 

--- a/src/rhosocial/activerecord/backend/dialect/protocols.py
+++ b/src/rhosocial/activerecord/backend/dialect/protocols.py
@@ -87,7 +87,7 @@ class CollationSupport(Protocol):
         """Validate a collation expression and return its SQL representation."""
         ...  # pragma: no cover
 
-    def format_collate_expression(self, expr: Any) -> Tuple[str, tuple]:
+    def format_collate_expression(self, expr: "CollateExpression") -> Tuple[str, tuple]:
         """Format expression-level COLLATE."""
         ...  # pragma: no cover
 

--- a/src/rhosocial/activerecord/backend/expression/__init__.py
+++ b/src/rhosocial/activerecord/backend/expression/__init__.py
@@ -40,6 +40,11 @@ from .core import (
     Literal,
     WildcardExpression,
 )
+from .collation import (
+    CollationName,
+    CollateExpression,
+    collate,
+)
 from .predicates import (
     ComparisonPredicate,
     LogicalPredicate,

--- a/src/rhosocial/activerecord/backend/expression/__init__.py
+++ b/src/rhosocial/activerecord/backend/expression/__init__.py
@@ -41,7 +41,6 @@ from .core import (
     WildcardExpression,
 )
 from .collation import (
-    CollationName,
     CollateExpression,
     collate,
 )
@@ -325,6 +324,9 @@ __all__ = [
     "TableExpression",
     "Literal",
     "WildcardExpression",
+    # Collation expressions
+    "CollateExpression",
+    "collate",
     # Predicates
     "ComparisonPredicate",
     "LogicalPredicate",

--- a/src/rhosocial/activerecord/backend/expression/bases.py
+++ b/src/rhosocial/activerecord/backend/expression/bases.py
@@ -53,7 +53,7 @@ def is_sql_query_and_params(obj):
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..dialect import SQLDialectBase
-    from .collation import CollateExpression, CollationName
+    from .collation import CollateExpression
 
 
 @runtime_checkable
@@ -192,7 +192,11 @@ class SQLValueExpression(BaseExpression):
         super().__init__(dialect)
         self._cast_types: list = []
 
-    def collate(self, collation: Union[str, Enum, "CollationName"]) -> "CollateExpression":
+    def collate(
+        self,
+        collation: Union[str, Enum],
+        **collation_options: Any,
+    ) -> "CollateExpression":
         """
         Apply an explicit SQL COLLATE clause to this value expression.
 
@@ -203,4 +207,4 @@ class SQLValueExpression(BaseExpression):
         """
         from .collation import CollateExpression
 
-        return CollateExpression(self.dialect, self, collation)
+        return CollateExpression(self.dialect, self, collation, **collation_options)

--- a/src/rhosocial/activerecord/backend/expression/bases.py
+++ b/src/rhosocial/activerecord/backend/expression/bases.py
@@ -11,7 +11,8 @@ import abc
 import inspect
 import sys
 import warnings
-from typing import Dict, Any, Tuple, Protocol, TYPE_CHECKING
+from enum import Enum
+from typing import Dict, Any, Tuple, Protocol, TYPE_CHECKING, Union
 from typing import runtime_checkable
 
 if sys.version_info >= (3, 10):
@@ -52,6 +53,7 @@ def is_sql_query_and_params(obj):
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..dialect import SQLDialectBase
+    from .collation import CollateExpression, CollationName
 
 
 @runtime_checkable
@@ -178,8 +180,27 @@ class SQLValueExpression(BaseExpression):
     """
     Abstract base class for SQL expressions that return a non-boolean value
     (e.g., integer, string, date).
+
+    This class may define convenience factory methods for SQL value expressions.
+    These methods only guarantee syntactically valid SQL expression generation.
+    They do not validate whether the underlying database value type supports the
+    generated operation, so the final executability may still depend on backend
+    type rules.
     """
 
     def __init__(self, dialect: "SQLDialectBase"):
         super().__init__(dialect)
         self._cast_types: list = []
+
+    def collate(self, collation: Union[str, Enum, "CollationName"]) -> "CollateExpression":
+        """
+        Apply an explicit SQL COLLATE clause to this value expression.
+
+        This method only guarantees syntactically valid COLLATE expression
+        generation. It does not validate whether the underlying database value
+        type supports collation. Callers must apply it only to expressions that
+        are valid for the target backend, typically text/string expressions.
+        """
+        from .collation import CollateExpression
+
+        return CollateExpression(self.dialect, self, collation)

--- a/src/rhosocial/activerecord/backend/expression/collation.py
+++ b/src/rhosocial/activerecord/backend/expression/collation.py
@@ -3,10 +3,8 @@
 Collation expression support for SQL value expressions.
 """
 
-import re
-from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Union, TYPE_CHECKING
+from typing import Any, Dict, Optional, Union, TYPE_CHECKING
 
 from .bases import SQLQueryAndParams, SQLValueExpression
 from .mixins import (
@@ -19,54 +17,6 @@ from .mixins import (
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..dialect import SQLDialectBase
-
-_COLLATION_PART_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$-]*$")
-_UNSAFE_COLLATION_TOKENS = (";", "--", "/*", "*/", "#", "'", '"', "`", "[", "]")
-
-
-@dataclass(frozen=True)
-class CollationName:
-    """Structured SQL collation name."""
-
-    name: str
-    schema: Optional[str] = None
-    keyword: Optional[str] = None
-
-    def __post_init__(self) -> None:
-        if self.keyword is not None:
-            self._validate_part(self.keyword, "keyword")
-            if self.schema is not None:
-                raise ValueError("Collation keyword cannot be schema-qualified")
-            if self.name != self.keyword:
-                raise ValueError("Collation keyword name must match keyword")
-            return
-
-        self._validate_part(self.name, "name")
-        if self.schema is not None:
-            self._validate_part(self.schema, "schema")
-
-    @classmethod
-    def from_value(cls, value: Union[str, Enum, "CollationName"]) -> "CollationName":
-        if isinstance(value, CollationName):
-            return value
-        if isinstance(value, Enum):
-            return cls(str(value.value))
-        return cls(value)
-
-    @classmethod
-    def as_keyword(cls, keyword: str) -> "CollationName":
-        return cls(keyword, keyword=keyword)
-
-    @staticmethod
-    def _validate_part(value: str, part_name: str) -> None:
-        if not isinstance(value, str) or not value:
-            raise ValueError(f"Collation {part_name} must be a non-empty string")
-        if any(char.isspace() or ord(char) < 32 for char in value):
-            raise ValueError(f"Unsafe collation {part_name}: {value!r}")
-        if any(token in value for token in _UNSAFE_COLLATION_TOKENS):
-            raise ValueError(f"Unsafe collation {part_name}: {value!r}")
-        if not _COLLATION_PART_RE.fullmatch(value):
-            raise ValueError(f"Unsafe collation {part_name}: {value!r}")
 
 
 class CollateExpression(
@@ -83,12 +33,20 @@ class CollateExpression(
         self,
         dialect: "SQLDialectBase",
         expression: SQLValueExpression,
-        collation: Union[str, Enum, CollationName],
+        collation: Union[str, Enum],
+        **collation_options: Any,
     ):
         super().__init__(dialect)
         self.expression = expression
-        self.collation = CollationName.from_value(collation)
+        self.collation = collation
+        self.collation_options: Dict[str, Any] = dict(collation_options)
         self.alias: Optional[str] = None
+
+    @property
+    def collation_name(self) -> str:
+        if isinstance(self.collation, Enum):
+            return str(self.collation.value)
+        return str(self.collation)
 
     def to_sql(self) -> SQLQueryAndParams:
         sql, params = self.dialect.format_collate_expression(self)
@@ -104,6 +62,7 @@ class CollateExpression(
 
 def collate(
     expression: SQLValueExpression,
-    collation: Union[str, Enum, CollationName],
+    collation: Union[str, Enum],
+    **collation_options: Any,
 ) -> CollateExpression:
-    return CollateExpression(expression.dialect, expression, collation)
+    return CollateExpression(expression.dialect, expression, collation, **collation_options)

--- a/src/rhosocial/activerecord/backend/expression/collation.py
+++ b/src/rhosocial/activerecord/backend/expression/collation.py
@@ -1,0 +1,109 @@
+# src/rhosocial/activerecord/backend/expression/collation.py
+"""
+Collation expression support for SQL value expressions.
+"""
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Union, TYPE_CHECKING
+
+from .bases import SQLQueryAndParams, SQLValueExpression
+from .mixins import (
+    AliasableMixin,
+    ArithmeticMixin,
+    ComparisonMixin,
+    StringMixin,
+    TypeCastingMixin,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..dialect import SQLDialectBase
+
+_COLLATION_PART_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$-]*$")
+_UNSAFE_COLLATION_TOKENS = (";", "--", "/*", "*/", "#", "'", '"', "`", "[", "]")
+
+
+@dataclass(frozen=True)
+class CollationName:
+    """Structured SQL collation name."""
+
+    name: str
+    schema: Optional[str] = None
+    keyword: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.keyword is not None:
+            self._validate_part(self.keyword, "keyword")
+            if self.schema is not None:
+                raise ValueError("Collation keyword cannot be schema-qualified")
+            if self.name != self.keyword:
+                raise ValueError("Collation keyword name must match keyword")
+            return
+
+        self._validate_part(self.name, "name")
+        if self.schema is not None:
+            self._validate_part(self.schema, "schema")
+
+    @classmethod
+    def from_value(cls, value: Union[str, Enum, "CollationName"]) -> "CollationName":
+        if isinstance(value, CollationName):
+            return value
+        if isinstance(value, Enum):
+            return cls(str(value.value))
+        return cls(value)
+
+    @classmethod
+    def as_keyword(cls, keyword: str) -> "CollationName":
+        return cls(keyword, keyword=keyword)
+
+    @staticmethod
+    def _validate_part(value: str, part_name: str) -> None:
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"Collation {part_name} must be a non-empty string")
+        if any(char.isspace() or ord(char) < 32 for char in value):
+            raise ValueError(f"Unsafe collation {part_name}: {value!r}")
+        if any(token in value for token in _UNSAFE_COLLATION_TOKENS):
+            raise ValueError(f"Unsafe collation {part_name}: {value!r}")
+        if not _COLLATION_PART_RE.fullmatch(value):
+            raise ValueError(f"Unsafe collation {part_name}: {value!r}")
+
+
+class CollateExpression(
+    AliasableMixin,
+    ArithmeticMixin,
+    ComparisonMixin,
+    StringMixin,
+    TypeCastingMixin,
+    SQLValueExpression,
+):
+    """Applies an explicit collation to a SQL value expression."""
+
+    def __init__(
+        self,
+        dialect: "SQLDialectBase",
+        expression: SQLValueExpression,
+        collation: Union[str, Enum, CollationName],
+    ):
+        super().__init__(dialect)
+        self.expression = expression
+        self.collation = CollationName.from_value(collation)
+        self.alias: Optional[str] = None
+
+    def to_sql(self) -> SQLQueryAndParams:
+        sql, params = self.dialect.format_collate_expression(self)
+
+        for target_type in self._cast_types:
+            sql, params = self.dialect.format_cast_expression(sql, target_type, params, None)
+
+        if self.alias:
+            sql = f"{sql} AS {self.dialect.format_identifier(self.alias)}"
+
+        return sql, params
+
+
+def collate(
+    expression: SQLValueExpression,
+    collation: Union[str, Enum, CollationName],
+) -> CollateExpression:
+    return CollateExpression(expression.dialect, expression, collation)

--- a/src/rhosocial/activerecord/backend/impl/dummy/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/dummy/dialect.py
@@ -42,6 +42,7 @@ from typing import Dict, List, Tuple, TYPE_CHECKING
 
 from rhosocial.activerecord.backend.dialect.base import SQLDialectBase
 from rhosocial.activerecord.backend.dialect.protocols import (
+    CollationSupport,
     WindowFunctionSupport,
     CTESupport,
     WildcardSupport,
@@ -81,6 +82,7 @@ from rhosocial.activerecord.backend.dialect.protocols import (
     SQLFunctionSupport,
 )
 from rhosocial.activerecord.backend.dialect.mixins import (
+    CollationMixin,
     WindowFunctionMixin,
     CTEMixin,
     AdvancedGroupingMixin,
@@ -121,6 +123,7 @@ if TYPE_CHECKING:
 
 class DummyDialect(
     SQLDialectBase,
+    CollationMixin,
     WindowFunctionMixin,
     CTEMixin,
     AdvancedGroupingMixin,
@@ -154,6 +157,7 @@ class DummyDialect(
     # Introspection Mixin
     IntrospectionMixin,
     # Protocols for type checking
+    CollationSupport,
     WindowFunctionSupport,
     CTESupport,
     WildcardSupport,
@@ -203,6 +207,9 @@ class DummyDialect(
         self._version = (1, 0, 0)
 
     # region Protocol Support Checks - Core Features
+    def supports_collate_expression(self) -> bool:
+        return True
+
     def supports_window_functions(self) -> bool:
         return True
 

--- a/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
@@ -6,6 +6,7 @@ This dialect implements only the protocols for features that SQLite actually sup
 based on the SQLite version provided at initialization.
 """
 
+import re
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 from rhosocial.activerecord.backend.expression.transaction import BeginTransactionExpression
@@ -84,7 +85,7 @@ from .mixins import SQLitePragmaMixin, SQLiteIntrospectionCapabilityMixin, SQLit
 
 if TYPE_CHECKING:
     from rhosocial.activerecord.backend.expression import bases
-    from rhosocial.activerecord.backend.expression.collation import CollationName
+    from rhosocial.activerecord.backend.expression.collation import CollateExpression
     from rhosocial.activerecord.backend.expression.advanced_functions import ArrayExpression, OrderedSetAggregation
     from rhosocial.activerecord.backend.expression.graph import MatchClause
     from rhosocial.activerecord.backend.expression.query_parts import (
@@ -118,6 +119,7 @@ _SUGGESTION_MATERIALIZED_VIEW_ALT = (
     "or creating tables to store precomputed results."
 )
 _SUGGESTION_FOR_UPDATE_SET_OP = "SQLite does not support FOR UPDATE clause in set operations (UNION, INTERSECT, EXCEPT)"
+_COLLATION_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class SQLiteDialect(
@@ -338,13 +340,16 @@ class SQLiteDialect(
         """SQLite supports expression-level COLLATE."""
         return True
 
-    def validate_collation_name(self, collation: "CollationName") -> str:
+    def validate_collation_name(self, expr: "CollateExpression") -> str:
         """Validate SQLite collation names and return their SQL representation."""
-        if collation.schema is not None:
-            from rhosocial.activerecord.backend.dialect.exceptions import UnsupportedFeatureError
-
+        if "schema" in expr.collation_options:
             raise UnsupportedFeatureError(self.name, "schema-qualified COLLATE")
-        return collation.keyword or collation.name
+        if expr.collation_options:
+            unsupported = ", ".join(sorted(expr.collation_options))
+            raise UnsupportedFeatureError(self.name, f"COLLATE options: {unsupported}")
+        if not _COLLATION_NAME_RE.fullmatch(expr.collation_name):
+            raise ValueError(f"Unsupported SQLite collation: {expr.collation_name!r}")
+        return expr.collation_name
 
     # Additional protocol support methods for features SQLite doesn't support
     def supports_rollup(self) -> bool:

--- a/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
@@ -337,8 +337,8 @@ class SQLiteDialect(
         """SQLite supports expression-level COLLATE."""
         return True
 
-    def format_collation_name(self, collation) -> str:
-        """Format SQLite collation names as safe bare tokens."""
+    def validate_collation_name(self, collation) -> str:
+        """Validate SQLite collation names and return their SQL representation."""
         if collation.schema is not None:
             from rhosocial.activerecord.backend.dialect.exceptions import UnsupportedFeatureError
 

--- a/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
@@ -84,6 +84,7 @@ from .mixins import SQLitePragmaMixin, SQLiteIntrospectionCapabilityMixin, SQLit
 
 if TYPE_CHECKING:
     from rhosocial.activerecord.backend.expression import bases
+    from rhosocial.activerecord.backend.expression.collation import CollationName
     from rhosocial.activerecord.backend.expression.advanced_functions import ArrayExpression, OrderedSetAggregation
     from rhosocial.activerecord.backend.expression.graph import MatchClause
     from rhosocial.activerecord.backend.expression.query_parts import (
@@ -337,7 +338,7 @@ class SQLiteDialect(
         """SQLite supports expression-level COLLATE."""
         return True
 
-    def validate_collation_name(self, collation) -> str:
+    def validate_collation_name(self, collation: "CollationName") -> str:
         """Validate SQLite collation names and return their SQL representation."""
         if collation.schema is not None:
             from rhosocial.activerecord.backend.dialect.exceptions import UnsupportedFeatureError

--- a/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/sqlite/dialect.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from rhosocial.activerecord.backend.expression.transaction import BeginTransactionExpression
 from rhosocial.activerecord.backend.dialect.base import SQLDialectBase
 from rhosocial.activerecord.backend.dialect.protocols import (
+    CollationSupport,
     CTESupport,
     FilterClauseSupport,
     WindowFunctionSupport,
@@ -48,6 +49,7 @@ from rhosocial.activerecord.backend.dialect.protocols import (
     SQLFunctionSupport,
 )
 from rhosocial.activerecord.backend.dialect.mixins import (
+    CollationMixin,
     CTEMixin,
     FilterClauseMixin,
     WindowFunctionMixin,
@@ -120,6 +122,7 @@ _SUGGESTION_FOR_UPDATE_SET_OP = "SQLite does not support FOR UPDATE clause in se
 class SQLiteDialect(
     SQLDialectBase,
     # Include mixins for features that SQLite supports (with version-dependent implementations)
+    CollationMixin,
     CTEMixin,
     FilterClauseMixin,
     WindowFunctionMixin,
@@ -154,6 +157,7 @@ class SQLiteDialect(
     SQLiteVirtualTableMixin,
     SQLiteReindexMixin,
     # Protocols for type checking
+    CollationSupport,
     CTESupport,
     FilterClauseSupport,
     WindowFunctionSupport,
@@ -328,6 +332,18 @@ class SQLiteDialect(
             col_sql = f"{col_sql} AS {self.format_identifier(alias)}"
 
         return col_sql, ()
+
+    def supports_collate_expression(self) -> bool:
+        """SQLite supports expression-level COLLATE."""
+        return True
+
+    def format_collation_name(self, collation) -> str:
+        """Format SQLite collation names as safe bare tokens."""
+        if collation.schema is not None:
+            from rhosocial.activerecord.backend.dialect.exceptions import UnsupportedFeatureError
+
+            raise UnsupportedFeatureError(self.name, "schema-qualified COLLATE")
+        return collation.keyword or collation.name
 
     # Additional protocol support methods for features SQLite doesn't support
     def supports_rollup(self) -> bool:

--- a/tests/rhosocial/activerecord_test/feature/query/sqlite/test_collation_expression.py
+++ b/tests/rhosocial/activerecord_test/feature/query/sqlite/test_collation_expression.py
@@ -76,13 +76,12 @@ class TestSQLiteCollationExpression:
         assert sql == 'CAST("name" COLLATE NOCASE AS TEXT) AS "normalized_name"'
         assert params == ()
 
-    def test_schema_qualified_collation_uses_standard_identifier_format(self):
+    def test_default_collation_validation_requires_dialect_override(self):
         dialect = StandardCollationDialect()
-        name = CollationName("case_insensitive", schema="public")
+        expr = Column(dialect, "name").collate("NOCASE")
 
-        sql = dialect.format_collation_name(name)
-
-        assert sql == '"public"."case_insensitive"'
+        with pytest.raises(Exception, match="COLLATE collation validation"):
+            expr.to_sql()
 
     def test_sqlite_rejects_schema_qualified_collation(self, dialect):
         expr = Column(dialect, "name").collate(CollationName("case_insensitive", schema="public"))

--- a/tests/rhosocial/activerecord_test/feature/query/sqlite/test_collation_expression.py
+++ b/tests/rhosocial/activerecord_test/feature/query/sqlite/test_collation_expression.py
@@ -9,7 +9,7 @@ import pytest
 
 from rhosocial.activerecord.backend.dialect.base import SQLDialectBase
 from rhosocial.activerecord.backend.dialect.mixins import CollationMixin
-from rhosocial.activerecord.backend.expression import CollationName, Column, Literal, collate
+from rhosocial.activerecord.backend.expression import Column, Literal, collate
 from rhosocial.activerecord.backend.impl.sqlite.dialect import SQLiteDialect
 
 
@@ -83,8 +83,14 @@ class TestSQLiteCollationExpression:
         with pytest.raises(Exception, match="COLLATE collation validation"):
             expr.to_sql()
 
+    def test_collate_expression_stores_backend_options(self, dialect):
+        expr = Column(dialect, "name").collate("case_insensitive", schema="public")
+
+        assert expr.collation_name == "case_insensitive"
+        assert expr.collation_options == {"schema": "public"}
+
     def test_sqlite_rejects_schema_qualified_collation(self, dialect):
-        expr = Column(dialect, "name").collate(CollationName("case_insensitive", schema="public"))
+        expr = Column(dialect, "name").collate("case_insensitive", schema="public")
 
         with pytest.raises(Exception, match="schema-qualified COLLATE"):
             expr.to_sql()
@@ -106,8 +112,10 @@ class TestSQLiteCollationExpression:
         ],
     )
     def test_rejects_unsafe_collation_names(self, dialect, collation):
+        expr = Column(dialect, "name").collate(collation)
+
         with pytest.raises(ValueError):
-            Column(dialect, "name").collate(collation)
+            expr.to_sql()
 
     def test_collate_executes_case_insensitive_match(self, order_fixtures):
         User, _, _ = order_fixtures

--- a/tests/rhosocial/activerecord_test/feature/query/sqlite/test_collation_expression.py
+++ b/tests/rhosocial/activerecord_test/feature/query/sqlite/test_collation_expression.py
@@ -1,0 +1,130 @@
+# tests/rhosocial/activerecord_test/feature/query/sqlite/test_collation_expression.py
+"""
+Tests for expression-level COLLATE support on SQLite.
+"""
+
+from enum import Enum
+
+import pytest
+
+from rhosocial.activerecord.backend.dialect.base import SQLDialectBase
+from rhosocial.activerecord.backend.dialect.mixins import CollationMixin
+from rhosocial.activerecord.backend.expression import CollationName, Column, Literal, collate
+from rhosocial.activerecord.backend.impl.sqlite.dialect import SQLiteDialect
+
+
+class StandardCollationDialect(SQLDialectBase, CollationMixin):
+    def supports_collate_expression(self) -> bool:
+        return True
+
+
+class SQLiteCollation(Enum):
+    NOCASE = "NOCASE"
+
+
+@pytest.fixture
+def dialect():
+    return SQLiteDialect()
+
+
+class TestSQLiteCollationExpression:
+    def test_column_collate_generates_sql(self, dialect):
+        expr = Column(dialect, "name", table="users").collate("NOCASE")
+
+        sql, params = expr.to_sql()
+
+        assert sql == '"users"."name" COLLATE NOCASE'
+        assert params == ()
+
+    def test_function_collate_generates_sql(self, dialect):
+        expr = collate(Column(dialect, "name"), "BINARY")
+
+        sql, params = expr.to_sql()
+
+        assert sql == '"name" COLLATE BINARY'
+        assert params == ()
+
+    def test_enum_collate_generates_sql(self, dialect):
+        expr = Column(dialect, "name").collate(SQLiteCollation.NOCASE)
+
+        sql, params = expr.to_sql()
+
+        assert sql == '"name" COLLATE NOCASE'
+        assert params == ()
+
+    def test_literal_collate_preserves_parameter_binding(self, dialect):
+        expr = Literal(dialect, "Alice").collate("NOCASE")
+
+        sql, params = expr.to_sql()
+
+        assert sql == "? COLLATE NOCASE"
+        assert params == ("Alice",)
+
+    def test_collate_participates_in_comparison(self, dialect):
+        predicate = Column(dialect, "name").collate("NOCASE") == "alice"
+
+        sql, params = predicate.to_sql()
+
+        assert sql == '"name" COLLATE NOCASE = ?'
+        assert params == ("alice",)
+
+    def test_collate_supports_alias_and_cast(self, dialect):
+        expr = Column(dialect, "name").collate("NOCASE").cast("TEXT").as_("normalized_name")
+
+        sql, params = expr.to_sql()
+
+        assert sql == 'CAST("name" COLLATE NOCASE AS TEXT) AS "normalized_name"'
+        assert params == ()
+
+    def test_schema_qualified_collation_uses_standard_identifier_format(self):
+        dialect = StandardCollationDialect()
+        name = CollationName("case_insensitive", schema="public")
+
+        sql = dialect.format_collation_name(name)
+
+        assert sql == '"public"."case_insensitive"'
+
+    def test_sqlite_rejects_schema_qualified_collation(self, dialect):
+        expr = Column(dialect, "name").collate(CollationName("case_insensitive", schema="public"))
+
+        with pytest.raises(Exception, match="schema-qualified COLLATE"):
+            expr.to_sql()
+
+    @pytest.mark.parametrize(
+        "collation",
+        [
+            "NOCASE; DROP TABLE users",
+            "NOCASE -- comment",
+            "NOCASE/*comment*/",
+            "# comment",
+            "",
+            "has space",
+            "has\tcontrol",
+            'quoted"name',
+            "quoted'name",
+            "quoted`name",
+            "[bracketed]",
+        ],
+    )
+    def test_rejects_unsafe_collation_names(self, dialect, collation):
+        with pytest.raises(ValueError):
+            Column(dialect, "name").collate(collation)
+
+    def test_collate_executes_case_insensitive_match(self, order_fixtures):
+        User, _, _ = order_fixtures
+        User(username="Alice", email="alice@example.com", age=30).save()
+        User(username="bob", email="bob@example.com", age=25).save()
+
+        results = User.query().where(User.c.username.collate("NOCASE") == "alice").all()
+
+        assert [user.username for user in results] == ["Alice"]
+
+    def test_collate_executes_case_insensitive_order(self, order_fixtures):
+        User, _, _ = order_fixtures
+        User(username="bob", email="bob@example.com", age=20).save()
+        User(username="Alice", email="alice@example.com", age=20).save()
+        User(username="charlie", email="charlie@example.com", age=20).save()
+
+        results = User.query().order_by(User.c.username.collate("NOCASE")).all()
+
+        assert [user.username for user in results] == ["Alice", "bob", "charlie"]


### PR DESCRIPTION
## Description

Adds expression-level `COLLATE` support to the core SQL expression system.

This introduces `CollateExpression` and `.collate()` helpers for value expressions, delegates backend-specific collation validation to dialect hooks, and implements SQLite collation validation/formatting. The design keeps expression objects responsible for collecting user input while dialects validate and render the final collation SQL fragment.

Adds # (issue)

## Type of change

- [x] `feat`: A new feature
- [ ] `docs`: Documentation only changes (if related to the new feature)
- [ ] `perf`: A code change that improves performance (if part of the feature)
- [x] `test`: Adding missing tests or correcting existing tests (for the new feature)
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries suchs as documentation generation (if related to the new feature)
- [ ] `ci`: Changes to our CI configuration files and scripts (if related to the new feature)
- [ ] `build`: Changes that affect the build system or external dependencies (if related to the new feature)
- [ ] `revert`: Reverts a previous commit

## Breaking Change

- [ ] Yes, for end-users (backward-incompatible API changes)
- [x] Yes, for backend developers (internal architectural changes that may affect custom implementations)
- [ ] No breaking changes

**Impact on End-Users:**
No backward-incompatible changes are expected for typical end-user applications. The new `.collate()` API is additive.

**Impact on Backend Developers (Custom Implementations):**
Custom dialects that want expression-level `COLLATE` support must implement `validate_collation_name(expr: CollateExpression) -> str`. The shared `CollationMixin.format_collate_expression()` now calls that hook and expects the returned value to be the final SQL representation for the collation.

## Related Repositories/Packages

Coordinated backend plugin changes were made separately for MySQL, PostgreSQL, MariaDB, Firebird, Oracle, SQL Server, and Snowflake so their dialect validation hooks accept `CollateExpression` and handle backend-specific options.

## Testing

- [x] I have added new tests to cover my changes.
- [x] I have updated existing tests to reflect my changes.
- [ ] All existing tests pass.
- [x] This change has been tested on SQLite.

**Test Plan:**

- `source .venv3.8/bin/activate && pytest tests/rhosocial/activerecord_test/feature/query/sqlite/test_collation_expression.py && deactivate`
- Result: `24 passed, 2 warnings`
- Local full test suite was skipped during PR preparation by request.

## Checklist

- [x] My code follows the project's [code style guidelines](./.gemini/code_style.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (Docstrings, `README.md`, etc.).
- [ ] My changes generate no new warnings.
- [ ] I have added a [Changelog fragment](./.gemini/version_control.md#5-changelog-management-with-towncrier) (`changelog.d/<issue_number>.<type>.md`).
- [x] I have verified that my changes do not introduce SQL injection vulnerabilities.
- [x] I have checked for potential performance regressions.

## Additional Notes

The expression layer only guarantees syntactically valid SQL expression generation. It does not determine whether a backend value type can execute a collation operation successfully; callers and backend tests remain responsible for type-level validity.
